### PR TITLE
Add client.mainWindow to focus main window

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ Create a new application with the following options:
 * `webdriverLogPath` - String path to a directory where Webdriver will write
   logs to. Setting this option enables `verbose` logging from Webdriver.
 * `webdriverOptions` - Object of additional options for Webdriver
+* `mainWindowMatcher` - function that takes a window url and returns true if the
+  url matches the main window's url. Specifying this function is required if you
+  have multiple window and expect `client.mainWindow` to return the "main" one
+  according to your criteria.
+  Defaults to a function that always returns `true`.
 
 ### Node Integration
 
@@ -448,6 +453,38 @@ Focus a window using its index from the `windowHandles()` array.
 
 ```js
 app.client.windowByIndex(1)
+```
+
+#### client.mainWindow()
+
+Focus the "main" window of the application. To determine which window is the
+main one, you must specify an option `mainWindowMatcher` to spectron's `Application` contructor (
+if `mainWindowMatcher` is not provided or if `mainWindowMatcher` return `false` for all windows,
+`client.mainWindow()` focuses the first window from the `windowHandles()` array).
+
+Chaining promises after `mainWindow` allows to get the focused window index in `windowHandles()` array.
+
+One use case for `client.mainWindow()`, is to allow the use of chrome-extensions
+while being able to select the "real" application window (since chrome-extensions count as
+windows too).
+
+```js
+const electronPath = require('electron') // Require Electron from the binaries included in node_modules.
+const path = require('path')
+
+var app = new Application({
+  path: electronPath,
+  args: [path.join(__dirname, '..')],
+  mainWindowMatcher: function (windowUrl) {
+    // Returns false if the window's url matches a chrome-extension's one and true otherwise
+    return !/chrome-extension/.test(windowUrl)
+  }
+})
+
+app.client.mainWindow()
+  .then(function (mainWindowIndex) {
+    console.log('The main window is now focused and its index in `windowHandles()` array is:' + mainWindowIndex)
+  })
 ```
 
 ### Accessibility Testing

--- a/lib/application.js
+++ b/lib/application.js
@@ -30,6 +30,7 @@ function Application (options) {
   this.webdriverLogPath = options.webdriverLogPath
   this.webdriverOptions = options.webdriverOptions || {}
   this.requireName = options.requireName || 'require'
+  this.mainWindowMatcher = options.mainWindowMatcher || function () { return true }
 
   this.api = new Api(this, this.requireName)
   this.setupPromiseness()
@@ -47,6 +48,7 @@ Application.prototype.start = function () {
   return self.exists()
     .then(function () { return self.startChromeDriver() })
     .then(function () { return self.createClient() })
+    .then(function () { return self.client.mainWindow() })
     .then(function () { return self.api.initialize() })
     .then(function () { return self.client.timeouts('script', self.waitTimeout) })
     .then(function () { self.running = true })
@@ -69,13 +71,16 @@ Application.prototype.stop = function () {
       }, self.quitTimeout)
     }
 
-    if (self.api.nodeIntegration) {
-      self.client.windowByIndex(0).electron.remote.app.quit().then(endClient, reject)
-    } else {
-      self.client.windowByIndex(0).execute(function () {
-        window.close()
-      }).then(endClient, reject)
-    }
+    self.client.mainWindow()
+      .then(function (mainWindowIndex) {
+        if (self.api.nodeIntegration) {
+          self.client.windowByIndex(mainWindowIndex).electron.remote.app.quit().then(endClient, reject)
+        } else {
+          self.client.windowByIndex(mainWindowIndex).execute(function () {
+            window.close()
+          }).then(endClient, reject)
+        }
+      })
   })
 }
 
@@ -211,6 +216,7 @@ Application.prototype.initializeClient = function (resolve, reject) {
 }
 
 Application.prototype.addCommands = function () {
+  var application = this
   this.client.addCommand('waitUntilTextExists', function (selector, text, timeout) {
     return this.waitUntil(function () {
       return this.isExisting(selector).then(function (exists) {
@@ -245,6 +251,27 @@ Application.prototype.addCommands = function () {
   this.client.addCommand('windowByIndex', function (index) {
     return this.windowHandles().then(getResponseValue).then(function (handles) {
       return this.window(handles[index])
+    })
+  })
+
+  this.client.addCommand('mainWindow', function (index) {
+    var self = this
+    return self.windowHandles().then(getResponseValue).then(function (handles) {
+      return (function testWindowAtIndex (index) {
+        return self.window(handles[index])
+          .then(self.getUrl)
+          .then(function (url) {
+            if (application.mainWindowMatcher(url)) {
+              return index
+            }
+            else if (index + 1 >= handles.length) {
+              return 0
+            }
+            else {
+              return testWindowAtIndex(index + 1)
+            }
+          })
+      })(0)
     })
   })
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -263,11 +263,9 @@ Application.prototype.addCommands = function () {
           .then(function (url) {
             if (application.mainWindowMatcher(url)) {
               return index
-            }
-            else if (index + 1 >= handles.length) {
+            } else if (index + 1 >= handles.length) {
               return 0
-            }
-            else {
+            } else {
               return testWindowAtIndex(index + 1)
             }
           })


### PR DESCRIPTION
This PR adds a new method `mainWindow` on app.client so that users of spectron can use custom logic to select the window that is considered as the main one in their application.

This PR also fixes `app.stop` behavior to use `mainWindow` instead of blindly focusing the window at index 0 when trying to close the app (when using chrome-extensions, there is no guarantee that the window at index 0 is the "real" application window and not a chrome-extension). If `mainWindow` does not find any "main" window, the window at index 0 will be focused and `app.stop` will behave just like today.