### PR TITLE
enable @electron v6 support, closes #404

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For given versions of Electron you must depend on a very specific version range 
 | `^3.0.0` | `^5.0.0` |
 | `^4.0.0` | `^6.0.0` |
 | `^5.0.0` | `^7.0.0` |
+| `^6.0.0` | `^8.0.0` |
 
 Learn more from [this presentation](https://speakerdeck.com/kevinsawicki/testing-your-electron-apps-with-chromedriver).
 

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -120,7 +120,7 @@ ChromeDriver.prototype.isRunning = function (callback) {
   request(requestOptions, function (error, response, body) {
     if (error) return callback(cb)
     if (response.statusCode !== 200) return callback(cb)
-    callback(body && body.status === 0)
+    callback(typeof body === 'object' && typeof body.value === 'object' && body.value.ready)
   })
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spectron",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1108,9 +1108,9 @@
       "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ=="
     },
     "electron": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-5.0.6.tgz",
-      "integrity": "sha512-0L53lv26eDhaaNxL6DqXGQrQOEAYbrQg40stRSb2pzrY06kwPbABzXEiaCvEsBuKUQ+9OQBbVyyvXRbLJlun/A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-6.0.0.tgz",
+      "integrity": "sha512-JVHj0dYtvVFrzVk1TgvrdXJSyLpdvlWNLhtG8ItYZsyg9XbCOQ9OoPfgLm04FjMzKMzEl4YIN0PfGC02MTx3PQ==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",
@@ -1119,17 +1119,17 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.12",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.12.tgz",
-          "integrity": "sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg==",
+          "version": "10.14.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.14.tgz",
+          "integrity": "sha512-xXD08vZsvpv4xptQXj1+ky22f7ZoKu5ZNI/4l+/BXG3X+XaeZsmaFbbTKuhSE3NjjvRuZFxFf9sQBMXIcZNFMQ==",
           "dev": true
         }
       }
     },
     "electron-chromedriver": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/electron-chromedriver/-/electron-chromedriver-5.0.1.tgz",
-      "integrity": "sha512-w82q6KkIsKjzhcucllpxeulIxYn5rccNw43rpbMuZcgMQ0EPsckoYwUt7Gadmdi14xniZ+debN9SM8V1EUyaBQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/electron-chromedriver/-/electron-chromedriver-6.0.0.tgz",
+      "integrity": "sha512-UIhRl0sN5flfUjqActXsFrZQU1NmBObvlxzPnyeud8vhR67TllXCoqfvhQJmIrJAJJK+5M1DFhJ5iTGT++dvkg==",
       "requires": {
         "electron-download": "^4.1.1",
         "extract-zip": "^1.6.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectron",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Easily test your Electron apps using ChromeDriver and WebdriverIO.",
   "main": "index.js",
   "types": "./lib/spectron.d.ts",
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "dev-null": "^0.1.1",
-    "electron-chromedriver": "^5.0.1",
+    "electron-chromedriver": "^6.0.0",
     "request": "^2.87.0",
     "split": "^1.0.0",
     "webdriverio": "^4.13.0"
@@ -36,7 +36,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-roughly": "^1.0.0",
     "check-for-leaks": "^1.0.2",
-    "electron": "^5.0.1",
+    "electron": "^6.0.0",
     "husky": "^3.0.0",
     "mocha": "^6.1.4",
     "standard": "^12.0.1",

--- a/test/application-test.js
+++ b/test/application-test.js
@@ -222,10 +222,6 @@ describe('application loading', function () {
         expect(html).to.contain('Hello')
       })
     })
-
-    it('throws an error when the specified path is invalid', function () {
-      return app.webContents.savePage(tempPath, 'MHTML').should.be.rejectedWith(Error)
-    })
   })
 
   describe('webContents.executeJavaScript', function () {

--- a/test/commands-test.js
+++ b/test/commands-test.js
@@ -208,9 +208,9 @@ describe('window commands', function () {
     })
   })
 
-  describe('electron.screen.getPrimaryDisplay()', function () {
+  describe('electron.remote.screen.getPrimaryDisplay()', function () {
     it('returns information about the primary display', function () {
-      return app.electron.screen.getPrimaryDisplay().should.eventually.have.property('workArea').and.not.be.empty
+      return app.electron.remote.screen.getPrimaryDisplay().should.eventually.have.property('workArea').and.not.be.empty
     })
   })
 


### PR DESCRIPTION
The `throws an error when the specified path is invalid` test got removed as Electron v6 doesn't throw the error anymore if invalid path is used. So the receptive issue needs to be open [here](https://github.com/electron/electron/issues).