### PR TITLE
feat: Use ES6 syntax (class, const/let, arrow functions)

### DIFF
--- a/lib/accessibility.js
+++ b/lib/accessibility.js
@@ -1,34 +1,34 @@
-var axsPath = require.resolve('../vendor/axs_testing')
+const axsPath = require.resolve('../vendor/axs_testing')
 
-exports.addCommand = function (client, requireName) {
-  client.addCommand('auditAccessibility', function (options) {
-    return this.execute(function (axsPath, requireName, options) {
+exports.addCommand = (client, requireName) => {
+  client.addCommand('auditAccessibility', (options) => {
+    return client.execute((axsPath, requireName, options) => {
       options = options || {}
-      var ignoreWarnings = options.ignoreWarnings || false
-      var ignoreRules = Array.isArray(options.ignoreRules) ? options.ignoreRules : []
+      const ignoreWarnings = options.ignoreWarnings || false
+      const ignoreRules = Array.isArray(options.ignoreRules) ? options.ignoreRules : []
 
-      var axs = window[requireName](axsPath)
-      var audit = axs.Audit.run(new axs.AuditConfiguration({
+      const axs = window[requireName](axsPath)
+      const audit = axs.Audit.run(new axs.AuditConfiguration({
         showUnsupportedRulesWarning: false
       }))
 
-      var failures = audit.filter(function (result) {
+      let failures = audit.filter((result) => {
         return result.result === 'FAIL'
       })
 
       if (ignoreWarnings) {
-        failures = failures.filter(function (result) {
+        failures = failures.filter((result) => {
           return result.rule.severity !== 'Warning'
         })
       }
 
-      failures = failures.filter(function (result) {
+      failures = failures.filter((result) => {
         return ignoreRules.indexOf(result.rule.code) === -1
       })
 
       if (failures.length > 0) {
-        var message = 'Accessibilty audit failed\n\n'
-        message += failures.map(function (result) {
+        let message = 'Accessibilty audit failed\n\n'
+        message += failures.map((result) => {
           return axs.Audit.accessibilityErrorMessage(result)
         }).join('\n\n')
 
@@ -38,7 +38,7 @@ exports.addCommand = function (client, requireName) {
           results: failures.map(function (result) {
             return {
               code: result.rule.code,
-              elements: result.elements.map(function (element) {
+              elements: result.elements.map((element) => {
                 return axs.utils.getQuerySelectorText(element)
               }),
               message: result.rule.heading,
@@ -54,7 +54,7 @@ exports.addCommand = function (client, requireName) {
           failed: false
         }
       }
-    }, axsPath, requireName, options).then(function (response) {
+    }, axsPath, requireName, options).then((response) => {
       return response.value
     })
   })

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,457 +1,433 @@
-var apiCache = {}
+const apiCache = {}
 
-function Api (app, requireName) {
-  this.app = app
-  this.requireName = requireName
-}
-
-Api.prototype.initialize = function () {
-  return this.load().then(this.addApiCommands.bind(this))
-}
-
-Api.prototype.addApiCommands = function (api) {
-  if (!this.nodeIntegration) return
-
-  this.addRenderProcessApis(api.electron)
-  this.addMainProcessApis(api.electron.remote)
-  this.addBrowserWindowApis(api.browserWindow)
-  this.addWebContentsApis(api.webContents)
-  this.addProcessApis(api.rendererProcess)
-
-  this.api = {
-    browserWindow: api.browserWindow,
-    electron: api.electron,
-    rendererProcess: api.rendererProcess,
-    webContents: api.webContents
+class Api {
+  constructor (app, requireName) {
+    this.app = app
+    this.requireName = requireName
   }
 
-  this.addClientProperties()
-}
+  initialize () {
+    return this.load().then(this.addApiCommands.bind(this))
+  }
 
-Api.prototype.load = function () {
-  var self = this
-  return this.isNodeIntegrationEnabled().then(function (nodeIntegration) {
-    self.nodeIntegration = nodeIntegration
-    if (!nodeIntegration) {
-      return {
-        electron: { remote: {} },
+  addApiCommands (api) {
+    if (!this.nodeIntegration) return
+
+    this.addRenderProcessApis(api.electron)
+    this.addMainProcessApis(api.electron.remote)
+    this.addBrowserWindowApis(api.browserWindow)
+    this.addWebContentsApis(api.webContents)
+    this.addProcessApis(api.rendererProcess)
+
+    this.api = {
+      browserWindow: api.browserWindow,
+      electron: api.electron,
+      rendererProcess: api.rendererProcess,
+      webContents: api.webContents
+    }
+
+    this.addClientProperties()
+  }
+
+  load () {
+    return this.isNodeIntegrationEnabled().then((nodeIntegration) => {
+      this.nodeIntegration = nodeIntegration
+      if (!nodeIntegration) {
+        return {
+          electron: { remote: {} },
+          browserWindow: {},
+          webContents: {},
+          rendererProcess: {}
+        }
+      }
+
+      return this.getVersion().then((version) => {
+        const api = apiCache[version]
+        if (api) return api
+
+        return this.loadApi().then((api) => {
+          if (version) apiCache[version] = api
+          return api
+        })
+      })
+    })
+  }
+
+  isNodeIntegrationEnabled () {
+    return this.app.client.execute((requireName) => {
+      return typeof window[requireName] === 'function'
+    }, this.requireName).then(getResponseValue)
+  }
+
+  getVersion () {
+    return this.app.client.execute((requireName) => {
+      const process = window[requireName]('process')
+      if (process != null && process.versions != null) {
+        return process.versions.electron
+      }
+    }, this.requireName).then(getResponseValue)
+  }
+
+  loadApi () {
+    return this.app.client.execute((requireName) => {
+      if (typeof window[requireName] !== 'function') {
+        throw new Error('Could not find global require method with name: ' + requireName)
+      }
+      const electron = window[requireName]('electron')
+      const process = window[requireName]('process')
+
+      const api = {
         browserWindow: {},
-        webContents: {},
-        rendererProcess: {}
+        electron: {},
+        rendererProcess: {},
+        webContents: {}
       }
-    }
 
-    return self.getVersion().then(function (version) {
-      var api = apiCache[version]
-      if (api) return api
+      const ignoreModule = (moduleName) => {
+        switch (moduleName) {
+          case 'CallbacksRegistry':
+          case 'deprecate':
+          case 'deprecations':
+          case 'hideInternalModules':
+          case 'Tray':
+            return true
+          case 'inAppPurchase':
+            return process.platform !== 'darwin'
+        }
+        return false
+      }
 
-      return self.loadApi().then(function (api) {
-        if (version) apiCache[version] = api
-        return api
+      const isRemoteFunction = (name) => {
+        switch (name) {
+          case 'BrowserWindow':
+          case 'Menu':
+          case 'MenuItem':
+            return false
+        }
+        return typeof electron.remote[name] === 'function'
+      }
+
+      const ignoreApi = (apiName) => {
+        switch (apiName) {
+          case 'prototype':
+            return true
+          default:
+            return apiName[0] === '_'
+        }
+      }
+
+      const addModule = (parent, parentName, name, api) => {
+        api[name] = {}
+        for (const key in parent[name]) {
+          if (ignoreApi(key)) continue
+          api[name][key] = parentName + '.' + name + '.' + key
+        }
+      }
+
+      const addRenderProcessModules = () => {
+        Object.getOwnPropertyNames(electron).forEach((key) => {
+          if (ignoreModule(key)) return
+          if (key === 'remote') return
+          addModule(electron, 'electron', key, api.electron)
+        })
+      }
+
+      const addMainProcessModules = () => {
+        api.electron.remote = {}
+        Object.getOwnPropertyNames(electron.remote).forEach((key) => {
+          if (ignoreModule(key)) return
+          if (isRemoteFunction(key)) {
+            api.electron.remote[key] = 'electron.remote.' + key
+          } else {
+            addModule(electron.remote, 'electron.remote', key, api.electron.remote)
+          }
+        })
+        addModule(electron.remote, 'electron.remote', 'process', api.electron.remote)
+      }
+
+      const addBrowserWindow = () => {
+        const currentWindow = electron.remote.getCurrentWindow()
+        for (const name in currentWindow) {
+          if (ignoreApi(name)) continue
+          const value = currentWindow[name]
+          if (typeof value === 'function') {
+            api.browserWindow[name] = 'browserWindow.' + name
+          }
+        }
+      }
+
+      const addWebContents = () => {
+        const webContents = electron.remote.getCurrentWebContents()
+        for (const name in webContents) {
+          if (ignoreApi(name)) continue
+          const value = webContents[name]
+          if (typeof value === 'function') {
+            api.webContents[name] = 'webContents.' + name
+          }
+        }
+      }
+
+      const addProcess = () => {
+        if (typeof process !== 'object') return
+
+        for (const name in process) {
+          if (ignoreApi(name)) continue
+          api.rendererProcess[name] = 'process.' + name
+        }
+      }
+
+      addRenderProcessModules()
+      addMainProcessModules()
+      addBrowserWindow()
+      addWebContents()
+      addProcess()
+
+      return api
+    }, this.requireName).then(getResponseValue)
+  }
+
+  addClientProperty (name) {
+    const self = this
+    const clientPrototype = Object.getPrototypeOf(this.app.client)
+    Object.defineProperty(clientPrototype, name, {
+      get: function () {
+        const client = this
+        return transformObject(self.api[name], {}, (value) => {
+          return client[value].bind(client)
+        })
+      }
+    })
+  }
+
+  addClientProperties () {
+    this.addClientProperty('electron')
+    this.addClientProperty('browserWindow')
+    this.addClientProperty('webContents')
+    this.addClientProperty('rendererProcess')
+
+    Object.defineProperty(Object.getPrototypeOf(this.app.client), 'mainProcess', {
+      get: function () {
+        return this.electron.remote.process
+      }
+    })
+  }
+
+  addRenderProcessApis (api) {
+    const electron = {}
+    this.app.electron = electron
+
+    Object.keys(api).forEach((moduleName) => {
+      if (moduleName === 'remote') return
+      electron[moduleName] = {}
+      const moduleApi = api[moduleName]
+
+      Object.keys(moduleApi).forEach((key) => {
+        const commandName = moduleApi[key]
+
+        this.app.client.addCommand(commandName, (...args) => {
+          return this.app.client.execute(callRenderApi, moduleName, key, args, this.requireName).then(getResponseValue)
+        })
+
+        electron[moduleName][key] = (...args) => {
+          return this.app.client[commandName].apply(this.app.client, args)
+        }
       })
     })
-  })
-}
+  }
 
-Api.prototype.isNodeIntegrationEnabled = function () {
-  return this.app.client.execute(function (requireName) {
-    return typeof window[requireName] === 'function'
-  }, this.requireName).then(getResponseValue)
-}
+  addMainProcessApis (api) {
+    const remote = {}
+    this.app.electron.remote = remote
 
-Api.prototype.getVersion = function () {
-  return this.app.client.execute(function (requireName) {
-    var process = window[requireName]('process')
-    if (process != null && process.versions != null) {
-      return process.versions.electron
-    }
-  }, this.requireName).then(getResponseValue)
-}
+    Object.keys(api).filter((propertyName) => {
+      return typeof api[propertyName] === 'string'
+    }).forEach((name) => {
+      const commandName = api[name]
 
-Api.prototype.loadApi = function () {
-  return this.app.client.execute(function (requireName) {
-    if (typeof window[requireName] !== 'function') {
-      throw new Error('Could not find global require method with name: ' + requireName)
-    }
-    var electron = window[requireName]('electron')
-    var process = window[requireName]('process')
-
-    var api = {
-      browserWindow: {},
-      electron: {},
-      rendererProcess: {},
-      webContents: {}
-    }
-
-    function ignoreModule (moduleName) {
-      switch (moduleName) {
-        case 'CallbacksRegistry':
-        case 'deprecate':
-        case 'deprecations':
-        case 'hideInternalModules':
-        case 'Tray':
-          return true
-        case 'inAppPurchase':
-          return process.platform !== 'darwin'
-      }
-      return false
-    }
-
-    function isRemoteFunction (name) {
-      switch (name) {
-        case 'BrowserWindow':
-        case 'Menu':
-        case 'MenuItem':
-          return false
-      }
-      return typeof electron.remote[name] === 'function'
-    }
-
-    function ignoreApi (apiName) {
-      switch (apiName) {
-        case 'prototype':
-          return true
-        default:
-          return apiName[0] === '_'
-      }
-    }
-
-    function addModule (parent, parentName, name, api) {
-      api[name] = {}
-      for (var key in parent[name]) {
-        if (ignoreApi(key)) continue
-        api[name][key] = parentName + '.' + name + '.' + key
-      }
-    }
-
-    function addRenderProcessModules () {
-      Object.getOwnPropertyNames(electron).forEach(function (key) {
-        if (ignoreModule(key)) return
-        if (key === 'remote') return
-        addModule(electron, 'electron', key, api.electron)
+      this.app.client.addCommand(commandName, (...args) => {
+        return this.app.client.execute(callMainApi, null, name, args, this.requireName).then(getResponseValue)
       })
+
+      remote[name] = (...args) => {
+        return this.app.client[commandName].apply(this.app.client, args)
+      }
+    })
+
+    Object.keys(api).filter((moduleName) => {
+      return typeof api[moduleName] === 'object'
+    }).forEach((moduleName) => {
+      remote[moduleName] = {}
+      const moduleApi = api[moduleName]
+
+      Object.keys(moduleApi).forEach((key) => {
+        const commandName = moduleApi[key]
+
+        this.app.client.addCommand(commandName, (...args) => {
+          return this.app.client.execute(callMainApi, moduleName, key, args, this.requireName).then(getResponseValue)
+        })
+
+        remote[moduleName][key] = (...args) => {
+          return this.app.client[commandName].apply(this.app.client, args)
+        }
+      })
+    })
+  }
+
+  addBrowserWindowApis (api) {
+    this.app.browserWindow = {}
+
+    const asyncApis = {
+      'browserWindow.capturePage': true
     }
 
-    function addMainProcessModules () {
-      api.electron.remote = {}
-      Object.getOwnPropertyNames(electron.remote).forEach(function (key) {
-        if (ignoreModule(key)) return
-        if (isRemoteFunction(key)) {
-          api.electron.remote[key] = 'electron.remote.' + key
+    Object.keys(api).filter((name) => {
+      return !asyncApis.hasOwnProperty(api[name])
+    }).forEach((name) => {
+      const commandName = api[name]
+
+      this.app.client.addCommand(commandName, (...args) => {
+        return this.app.client.execute(callBrowserWindowApi, name, args, this.requireName).then(getResponseValue)
+      })
+
+      this.app.browserWindow[name] = (...args) => {
+        return this.app.client[commandName].apply(this.app.client, args)
+      }
+    })
+
+    this.addCapturePageSupport()
+  }
+
+  addCapturePageSupport () {
+    this.app.client.addCommand('browserWindow.capturePage', (rect) => {
+      return this.app.client.executeAsync(async (rect, requireName, done) => {
+        const args = []
+        if (rect != null) args.push(rect)
+        const browserWindow = window[requireName]('electron').remote.getCurrentWindow()
+        const image = await browserWindow.capturePage.apply(browserWindow, args)
+        if (image != null) {
+          done(image.toPNG().toString('base64'))
         } else {
-          addModule(electron.remote, 'electron.remote', key, api.electron.remote)
+          done(image)
+        }
+      }, rect, this.requireName).then(getResponseValue).then((image) => {
+        return Buffer.from(image, 'base64')
+      })
+    })
+
+    this.app.browserWindow.capturePage = (...args) => {
+      return this.app.client['browserWindow.capturePage'].apply(this.app.client, args)
+    }
+  }
+
+  addWebContentsApis (api) {
+    this.app.webContents = {}
+
+    const asyncApis = {
+      'webContents.savePage': true,
+      'webContents.executeJavaScript': true
+    }
+
+    Object.keys(api).filter((name) => {
+      return !asyncApis.hasOwnProperty(api[name])
+    }).forEach((name) => {
+      const commandName = api[name]
+
+      this.app.client.addCommand(commandName, (...args) => {
+        return this.app.client.execute(callWebContentsApi, name, args, this.requireName).then(getResponseValue)
+      })
+
+      this.app.webContents[name] = (...args) => {
+        return this.app.client[commandName].apply(this.app.client, args)
+      }
+    })
+
+    this.addSavePageSupport()
+    this.addExecuteJavaScriptSupport()
+  }
+
+  addSavePageSupport () {
+    this.app.client.addCommand('webContents.savePage', (fullPath, saveType) => {
+      return this.app.client.executeAsync(async (fullPath, saveType, requireName, done) => {
+        const webContents = window[requireName]('electron').remote.getCurrentWebContents()
+        await webContents.savePage(fullPath, saveType)
+        done()
+      }, fullPath, saveType, this.requireName).then(getResponseValue).then((rawError) => {
+        if (rawError) {
+          const error = new Error(rawError.message)
+          if (rawError.name) error.name = rawError.name
+          throw error
         }
       })
-      addModule(electron.remote, 'electron.remote', 'process', api.electron.remote)
+    })
+
+    this.app.webContents.savePage = (...args) => {
+      return this.app.client['webContents.savePage'].apply(this.app.client, args)
     }
+  }
 
-    function addBrowserWindow () {
-      var currentWindow = electron.remote.getCurrentWindow()
-      for (var name in currentWindow) {
-        if (ignoreApi(name)) continue
-        var value = currentWindow[name]
-        if (typeof value === 'function') {
-          api.browserWindow[name] = 'browserWindow.' + name
-        }
-      }
+  addExecuteJavaScriptSupport () {
+    this.app.client.addCommand('webContents.executeJavaScript', (code, useGesture) => {
+      return this.app.client.executeAsync(async (code, useGesture, requireName, done) => {
+        const webContents = window[requireName]('electron').remote.getCurrentWebContents()
+        const result = await webContents.executeJavaScript(code, useGesture)
+        done(result)
+      }, code, useGesture, this.requireName).then(getResponseValue)
+    })
+
+    this.app.webContents.executeJavaScript = (...args) => {
+      return this.app.client['webContents.executeJavaScript'].apply(this.app.client, args)
     }
+  }
 
-    function addWebContents () {
-      var webContents = electron.remote.getCurrentWebContents()
-      for (var name in webContents) {
-        if (ignoreApi(name)) continue
-        var value = webContents[name]
-        if (typeof value === 'function') {
-          api.webContents[name] = 'webContents.' + name
-        }
-      }
-    }
+  addProcessApis (api) {
+    this.app.rendererProcess = {}
 
-    function addProcess () {
-      if (typeof process !== 'object') return
+    Object.keys(api).forEach((name) => {
+      const commandName = api[name]
 
-      for (var name in process) {
-        if (ignoreApi(name)) continue
-        api.rendererProcess[name] = 'process.' + name
-      }
-    }
-
-    addRenderProcessModules()
-    addMainProcessModules()
-    addBrowserWindow()
-    addWebContents()
-    addProcess()
-
-    return api
-  }, this.requireName).then(getResponseValue)
-}
-
-Api.prototype.addClientProperty = function (name) {
-  var self = this
-
-  var clientPrototype = Object.getPrototypeOf(self.app.client)
-  Object.defineProperty(clientPrototype, name, {
-    get: function () {
-      var client = this
-      return transformObject(self.api[name], {}, function (value) {
-        return client[value].bind(client)
-      })
-    }
-  })
-}
-
-Api.prototype.addClientProperties = function () {
-  this.addClientProperty('electron')
-  this.addClientProperty('browserWindow')
-  this.addClientProperty('webContents')
-  this.addClientProperty('rendererProcess')
-
-  Object.defineProperty(Object.getPrototypeOf(this.app.client), 'mainProcess', {
-    get: function () {
-      return this.electron.remote.process
-    }
-  })
-}
-
-Api.prototype.addRenderProcessApis = function (api) {
-  var app = this.app
-  var self = this
-  var electron = {}
-  app.electron = electron
-
-  Object.keys(api).forEach(function (moduleName) {
-    if (moduleName === 'remote') return
-    electron[moduleName] = {}
-    var moduleApi = api[moduleName]
-
-    Object.keys(moduleApi).forEach(function (key) {
-      var commandName = moduleApi[key]
-
-      app.client.addCommand(commandName, function () {
-        var args = Array.prototype.slice.call(arguments)
-        return this.execute(callRenderApi, moduleName, key, args, self.requireName).then(getResponseValue)
+      this.app.client.addCommand(commandName, (...args) => {
+        return this.app.client.execute(callProcessApi, name, args).then(getResponseValue)
       })
 
-      electron[moduleName][key] = function () {
-        return app.client[commandName].apply(app.client, arguments)
+      this.app.rendererProcess[name] = (...args) => {
+        return this.app.client[commandName].apply(this.app.client, args)
       }
     })
-  })
-}
 
-Api.prototype.addMainProcessApis = function (api) {
-  var app = this.app
-  var self = this
-  var remote = {}
-  app.electron.remote = remote
+    this.app.mainProcess = this.app.electron.remote.process
+  }
 
-  Object.keys(api).filter(function (propertyName) {
-    return typeof api[propertyName] === 'string'
-  }).forEach(function (name) {
-    var commandName = api[name]
+  transferPromiseness (target, promise) {
+    this.app.client.transferPromiseness(target, promise)
 
-    app.client.addCommand(commandName, function () {
-      var args = Array.prototype.slice.call(arguments)
-      return this.execute(callMainApi, null, name, args, self.requireName).then(getResponseValue)
-    })
+    if (!this.nodeIntegration) return
 
-    remote[name] = function () {
-      return app.client[commandName].apply(app.client, arguments)
-    }
-  })
-
-  Object.keys(api).filter(function (moduleName) {
-    return typeof api[moduleName] === 'object'
-  }).forEach(function (moduleName) {
-    remote[moduleName] = {}
-    var moduleApi = api[moduleName]
-
-    Object.keys(moduleApi).forEach(function (key) {
-      var commandName = moduleApi[key]
-
-      app.client.addCommand(commandName, function () {
-        var args = Array.prototype.slice.call(arguments)
-        return this.execute(callMainApi, moduleName, key, args, self.requireName).then(getResponseValue)
+    const addProperties = (source, target, moduleName) => {
+      const sourceModule = source[moduleName]
+      if (!sourceModule) return
+      target[moduleName] = transformObject(sourceModule, {}, (value, parent) => {
+        return value.bind(parent)
       })
-
-      remote[moduleName][key] = function () {
-        return app.client[commandName].apply(app.client, arguments)
-      }
-    })
-  })
-}
-
-Api.prototype.addBrowserWindowApis = function (api) {
-  var app = this.app
-  var self = this
-  app.browserWindow = {}
-
-  const asyncApis = {
-    'browserWindow.capturePage': true
-  }
-
-  Object.keys(api).filter(function (name) {
-    return !asyncApis.hasOwnProperty(api[name])
-  }).forEach(function (name) {
-    var commandName = api[name]
-
-    app.client.addCommand(commandName, function () {
-      var args = Array.prototype.slice.call(arguments)
-      return this.execute(callBrowserWindowApi, name, args, self.requireName).then(getResponseValue)
-    })
-
-    app.browserWindow[name] = function () {
-      return app.client[commandName].apply(app.client, arguments)
     }
-  })
 
-  this.addCapturePageSupport()
-}
+    addProperties(promise, target, 'webContents')
+    addProperties(promise, target, 'browserWindow')
+    addProperties(promise, target, 'electron')
+    addProperties(promise, target, 'mainProcess')
+    addProperties(promise, target, 'rendererProcess')
+  }
 
-Api.prototype.addCapturePageSupport = function () {
-  var app = this.app
-  var self = this
-
-  app.client.addCommand('browserWindow.capturePage', function (rect) {
-    return this.executeAsync(async function (rect, requireName, done) {
-      var args = []
-      if (rect != null) args.push(rect)
-      var browserWindow = window[requireName]('electron').remote.getCurrentWindow()
-      const image = await browserWindow.capturePage.apply(browserWindow, args)
-      if (image != null) {
-        done(image.toPNG().toString('base64'))
-      } else {
-        done(image)
-      }
-    }, rect, self.requireName).then(getResponseValue).then(function (image) {
-      return Buffer.from(image, 'base64')
-    })
-  })
-
-  app.browserWindow.capturePage = function () {
-    return app.client['browserWindow.capturePage'].apply(app.client, arguments)
+  logApi () {
+    const fs = require('fs')
+    const path = require('path')
+    const json = JSON.stringify(this.api, null, 2)
+    fs.writeFileSync(path.join(__dirname, 'api.json'), json)
   }
 }
 
-Api.prototype.addWebContentsApis = function (api) {
-  var app = this.app
-  var self = this
-  app.webContents = {}
-
-  const asyncApis = {
-    'webContents.savePage': true,
-    'webContents.executeJavaScript': true
-  }
-
-  Object.keys(api).filter(function (name) {
-    return !asyncApis.hasOwnProperty(api[name])
-  }).forEach(function (name) {
-    var commandName = api[name]
-
-    app.client.addCommand(commandName, function () {
-      var args = Array.prototype.slice.call(arguments)
-      return this.execute(callWebContentsApi, name, args, self.requireName).then(getResponseValue)
-    })
-
-    app.webContents[name] = function () {
-      return app.client[commandName].apply(app.client, arguments)
-    }
-  })
-
-  this.addSavePageSupport()
-  this.addExecuteJavaScriptSupport()
-}
-
-Api.prototype.addSavePageSupport = function () {
-  var app = this.app
-  var self = this
-
-  app.client.addCommand('webContents.savePage', function (fullPath, saveType) {
-    return this.executeAsync(async function (fullPath, saveType, requireName, done) {
-      var webContents = window[requireName]('electron').remote.getCurrentWebContents()
-      await webContents.savePage(fullPath, saveType)
-      done()
-    }, fullPath, saveType, self.requireName).then(getResponseValue).then(function (rawError) {
-      if (rawError) {
-        var error = new Error(rawError.message)
-        if (rawError.name) error.name = rawError.name
-        throw error
-      }
-    })
-  })
-
-  app.webContents.savePage = function () {
-    return app.client['webContents.savePage'].apply(app.client, arguments)
-  }
-}
-
-Api.prototype.addExecuteJavaScriptSupport = function () {
-  const app = this.app
-  const self = this
-
-  app.client.addCommand('webContents.executeJavaScript', function (code, useGesture) {
-    return this.executeAsync(async function (code, useGesture, requireName, done) {
-      const webContents = window[requireName]('electron').remote.getCurrentWebContents()
-      const result = await webContents.executeJavaScript(code, useGesture)
-      done(result)
-    }, code, useGesture, self.requireName).then(getResponseValue)
-  })
-
-  app.webContents.executeJavaScript = function () {
-    return app.client['webContents.executeJavaScript'].apply(app.client, arguments)
-  }
-}
-
-Api.prototype.addProcessApis = function (api) {
-  var app = this.app
-  app.rendererProcess = {}
-
-  Object.keys(api).forEach(function (name) {
-    var commandName = api[name]
-
-    app.client.addCommand(commandName, function () {
-      var args = Array.prototype.slice.call(arguments)
-      return this.execute(callProcessApi, name, args).then(getResponseValue)
-    })
-
-    app.rendererProcess[name] = function () {
-      return app.client[commandName].apply(app.client, arguments)
-    }
-  })
-
-  app.mainProcess = app.electron.remote.process
-}
-
-Api.prototype.transferPromiseness = function (target, promise) {
-  this.app.client.transferPromiseness(target, promise)
-
-  if (!this.nodeIntegration) return
-
-  var addProperties = function (source, target, moduleName) {
-    var sourceModule = source[moduleName]
-    if (!sourceModule) return
-    target[moduleName] = transformObject(sourceModule, {}, function (value, parent) {
-      return value.bind(parent)
-    })
-  }
-
-  addProperties(promise, target, 'webContents')
-  addProperties(promise, target, 'browserWindow')
-  addProperties(promise, target, 'electron')
-  addProperties(promise, target, 'mainProcess')
-  addProperties(promise, target, 'rendererProcess')
-}
-
-Api.prototype.logApi = function () {
-  var fs = require('fs')
-  var path = require('path')
-  var json = JSON.stringify(this.api, null, 2)
-  fs.writeFileSync(path.join(__dirname, 'api.json'), json)
-}
-
-function transformObject (input, output, callback) {
-  Object.keys(input).forEach(function (name) {
-    var value = input[name]
+const transformObject = (input, output, callback) => {
+  Object.keys(input).forEach((name) => {
+    const value = input[name]
     if (typeof value === 'object') {
       output[name] = {}
       transformObject(value, output[name], callback)
@@ -462,8 +438,8 @@ function transformObject (input, output, callback) {
   return output
 }
 
-function callRenderApi (moduleName, api, args, requireName) {
-  var module = window[requireName]('electron')[moduleName]
+const callRenderApi = (moduleName, api, args, requireName) => {
+  const module = window[requireName]('electron')[moduleName]
   if (typeof module[api] === 'function') {
     return module[api].apply(module, args)
   } else {
@@ -471,8 +447,8 @@ function callRenderApi (moduleName, api, args, requireName) {
   }
 }
 
-function callMainApi (moduleName, api, args, requireName) {
-  var module = window[requireName]('electron').remote
+const callMainApi = (moduleName, api, args, requireName) => {
+  let module = window[requireName]('electron').remote
   if (moduleName) {
     module = module[moduleName]
   }
@@ -483,17 +459,17 @@ function callMainApi (moduleName, api, args, requireName) {
   }
 }
 
-function callWebContentsApi (name, args, requireName) {
-  var webContents = window[requireName]('electron').remote.getCurrentWebContents()
+const callWebContentsApi = (name, args, requireName) => {
+  const webContents = window[requireName]('electron').remote.getCurrentWebContents()
   return webContents[name].apply(webContents, args)
 }
 
-function callBrowserWindowApi (name, args, requireName) {
-  var browserWindow = window[requireName]('electron').remote.getCurrentWindow()
+const callBrowserWindowApi = (name, args, requireName) => {
+  const browserWindow = window[requireName]('electron').remote.getCurrentWindow()
   return browserWindow[name].apply(browserWindow, args)
 }
 
-function callProcessApi (name, args) {
+const callProcessApi = (name, args) => {
   if (typeof process[name] === 'function') {
     return process[name].apply(process, args)
   } else {
@@ -501,7 +477,7 @@ function callProcessApi (name, args) {
   }
 }
 
-function getResponseValue (response) {
+const getResponseValue = (response) => {
   return response.value
 }
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -1,308 +1,301 @@
-var Accessibility = require('./accessibility')
-var Api = require('./api')
-var ChromeDriver = require('./chrome-driver')
-var DevNull = require('dev-null')
-var fs = require('fs')
-var path = require('path')
-var WebDriver = require('webdriverio')
+const Accessibility = require('./accessibility')
+const Api = require('./api')
+const ChromeDriver = require('./chrome-driver')
+const DevNull = require('dev-null')
+const fs = require('fs')
+const path = require('path')
+const WebDriver = require('webdriverio')
 
-function Application (options) {
-  options = options || {}
-  this.host = options.host || '127.0.0.1'
-  this.port = parseInt(options.port, 10) || 9515
+class Application {
+  constructor (options) {
+    options = options || {}
+    this.host = options.host || '127.0.0.1'
+    this.port = parseInt(options.port, 10) || 9515
 
-  this.quitTimeout = parseInt(options.quitTimeout, 10) || 1000
-  this.startTimeout = parseInt(options.startTimeout, 10) || 5000
-  this.waitTimeout = parseInt(options.waitTimeout, 10) || 5000
+    this.quitTimeout = parseInt(options.quitTimeout, 10) || 1000
+    this.startTimeout = parseInt(options.startTimeout, 10) || 5000
+    this.waitTimeout = parseInt(options.waitTimeout, 10) || 5000
 
-  this.connectionRetryCount = parseInt(options.connectionRetryCount, 10) || 10
-  this.connectionRetryTimeout = parseInt(options.connectionRetryTimeout, 10) || 30000
+    this.connectionRetryCount = parseInt(options.connectionRetryCount, 10) || 10
+    this.connectionRetryTimeout = parseInt(options.connectionRetryTimeout, 10) || 30000
 
-  this.nodePath = options.nodePath || process.execPath
-  this.path = options.path
+    this.nodePath = options.nodePath || process.execPath
+    this.path = options.path
 
-  this.args = options.args || []
-  this.chromeDriverArgs = options.chromeDriverArgs || []
-  this.env = options.env || {}
-  this.workingDirectory = options.cwd || process.cwd()
-  this.debuggerAddress = options.debuggerAddress
-  this.chromeDriverLogPath = options.chromeDriverLogPath
-  this.webdriverLogPath = options.webdriverLogPath
-  this.webdriverOptions = options.webdriverOptions || {}
-  this.requireName = options.requireName || 'require'
+    this.args = options.args || []
+    this.chromeDriverArgs = options.chromeDriverArgs || []
+    this.env = options.env || {}
+    this.workingDirectory = options.cwd || process.cwd()
+    this.debuggerAddress = options.debuggerAddress
+    this.chromeDriverLogPath = options.chromeDriverLogPath
+    this.webdriverLogPath = options.webdriverLogPath
+    this.webdriverOptions = options.webdriverOptions || {}
+    this.requireName = options.requireName || 'require'
 
-  this.api = new Api(this, this.requireName)
-  this.setupPromiseness()
-}
-
-Application.prototype.setupPromiseness = function () {
-  var self = this
-  self.transferPromiseness = function (target, promise) {
-    self.api.transferPromiseness(target, promise)
+    this.api = new Api(this, this.requireName)
+    this.setupPromiseness()
   }
-}
 
-Application.prototype.start = function () {
-  var self = this
-  return self.exists()
-    .then(function () { return self.startChromeDriver() })
-    .then(function () { return self.createClient() })
-    .then(function () { return self.api.initialize() })
-    .then(function () { return self.client.timeouts('script', self.waitTimeout) })
-    .then(function () { self.running = true })
-    .then(function () { return self })
-}
-
-Application.prototype.stop = function () {
-  var self = this
-
-  if (!self.isRunning()) return Promise.reject(Error('Application not running'))
-
-  return new Promise(function (resolve, reject) {
-    var endClient = function () {
-      setTimeout(function () {
-        self.client.end().then(function () {
-          self.chromeDriver.stop()
-          self.running = false
-          resolve(self)
-        }, reject)
-      }, self.quitTimeout)
+  setupPromiseness () {
+    this.transferPromiseness = (target, promise) => {
+      this.api.transferPromiseness(target, promise)
     }
-
-    if (self.api.nodeIntegration) {
-      self.client.windowByIndex(0).electron.remote.app.quit().then(endClient, reject)
-    } else {
-      self.client.windowByIndex(0).execute(function () {
-        window.close()
-      }).then(endClient, reject)
-    }
-  })
-}
-
-Application.prototype.restart = function () {
-  var self = this
-  return self.stop().then(function () {
-    return self.start()
-  })
-}
-
-Application.prototype.isRunning = function () {
-  return this.running
-}
-
-Application.prototype.getSettings = function () {
-  return {
-    host: this.host,
-    port: this.port,
-    quitTimeout: this.quitTimeout,
-    startTimeout: this.startTimeout,
-    waitTimeout: this.waitTimeout,
-    connectionRetryCount: this.connectionRetryCount,
-    connectionRetryTimeout: this.connectionRetryTimeout,
-    nodePath: this.nodePath,
-    path: this.path,
-    args: this.args,
-    chromeDriverArgs: this.chromeDriverArgs,
-    env: this.env,
-    workingDirectory: this.workingDirectory,
-    debuggerAddress: this.debuggerAddress,
-    chromeDriverLogPath: this.chromeDriverLogPath,
-    webdriverLogPath: this.webdriverLogPath,
-    webdriverOptions: this.webdriverOptions,
-    requireName: this.requireName
   }
-}
 
-Application.prototype.exists = function () {
-  var self = this
-  return new Promise(function (resolve, reject) {
-    // Binary path is ignored by ChromeDriver if debuggerAddress is set
-    if (self.debuggerAddress) return resolve()
+  start () {
+    return this.exists()
+      .then(() => { return this.startChromeDriver() })
+      .then(() => { return this.createClient() })
+      .then(() => { return this.api.initialize() })
+      .then(() => { return this.client.timeouts('script', this.waitTimeout) })
+      .then(() => { this.running = true })
+      .then(() => { return this })
+  }
 
-    if (typeof self.path !== 'string') {
-      return reject(Error('Application path must be a string'))
-    }
+  stop () {
+    if (!this.isRunning()) return Promise.reject(Error('Application not running'))
 
-    fs.stat(self.path, function (error, stat) {
-      if (error) return reject(error)
-      if (stat.isFile()) return resolve()
-      reject(Error('Application path specified is not a file: ' + self.path))
-    })
-  })
-}
+    return new Promise((resolve, reject) => {
+      const endClient = () => {
+        setTimeout(() => {
+          this.client.end().then(() => {
+            this.chromeDriver.stop()
+            this.running = false
+            resolve(this)
+          }, reject)
+        }, this.quitTimeout)
+      }
 
-Application.prototype.startChromeDriver = function () {
-  this.chromeDriver = new ChromeDriver(this.host, this.port, this.nodePath, this.startTimeout, this.workingDirectory, this.chromeDriverLogPath)
-  return this.chromeDriver.start()
-}
-
-Application.prototype.createClient = function () {
-  var self = this
-  return new Promise(function (resolve, reject) {
-    var args = []
-    args.push('spectron-path=' + self.path)
-    self.args.forEach(function (arg, index) {
-      args.push('spectron-arg' + index + '=' + arg)
-    })
-
-    for (var name in self.env) {
-      args.push('spectron-env-' + name + '=' + self.env[name])
-    }
-
-    self.chromeDriverArgs.forEach(function (arg) {
-      args.push(arg)
-    })
-
-    var isWin = process.platform === 'win32'
-    var launcherPath = path.join(__dirname, isWin ? 'launcher.bat' : 'launcher.js')
-
-    if (process.env.APPVEYOR) {
-      args.push('no-sandbox')
-    }
-
-    var options = {
-      host: self.host,
-      port: self.port,
-      waitforTimeout: self.waitTimeout,
-      connectionRetryCount: self.connectionRetryCount,
-      connectionRetryTimeout: self.connectionRetryTimeout,
-      desiredCapabilities: {
-        browserName: 'electron',
-        chromeOptions: {
-          binary: launcherPath,
-          args: args,
-          debuggerAddress: self.debuggerAddress,
-          windowTypes: ['app', 'webview']
-        }
-      },
-      logOutput: DevNull()
-    }
-
-    if (self.webdriverLogPath) {
-      options.logOutput = self.webdriverLogPath
-      options.logLevel = 'verbose'
-    }
-
-    Object.assign(options, self.webdriverOptions)
-
-    self.client = WebDriver.remote(options)
-    self.addCommands()
-    self.initializeClient(resolve, reject)
-  })
-}
-
-Application.prototype.initializeClient = function (resolve, reject) {
-  var maxTries = 10
-  var tries = 0
-  var self = this
-  var init = function () {
-    tries++
-    self.client.init().then(resolve, function (error) {
-      if (tries >= maxTries) {
-        error.message = 'Client initialization failed after ' + tries + ' attempts: '
-        error.message += error.type + ' ' + error.message
-        reject(error)
+      if (this.api.nodeIntegration) {
+        this.client.windowByIndex(0).electron.remote.app.quit().then(endClient, reject)
       } else {
-        global.setTimeout(init, 250)
+        this.client.windowByIndex(0).execute(() => {
+          window.close()
+        }).then(endClient, reject)
       }
     })
   }
-  init()
-}
 
-Application.prototype.addCommands = function () {
-  this.client.addCommand('waitUntilTextExists', function (selector, text, timeout) {
-    return this.waitUntil(function () {
-      return this.isExisting(selector).then(function (exists) {
-        if (!exists) return false
-        return this.getText(selector).then(function (selectorText) {
-          return Array.isArray(selectorText) ? selectorText.some(s => s.includes(text)) : selectorText.includes(text)
+  restart () {
+    return this.stop().then(() => {
+      return this.start()
+    })
+  }
+
+  isRunning () {
+    return this.running
+  }
+
+  getSettings () {
+    return {
+      host: this.host,
+      port: this.port,
+      quitTimeout: this.quitTimeout,
+      startTimeout: this.startTimeout,
+      waitTimeout: this.waitTimeout,
+      connectionRetryCount: this.connectionRetryCount,
+      connectionRetryTimeout: this.connectionRetryTimeout,
+      nodePath: this.nodePath,
+      path: this.path,
+      args: this.args,
+      chromeDriverArgs: this.chromeDriverArgs,
+      env: this.env,
+      workingDirectory: this.workingDirectory,
+      debuggerAddress: this.debuggerAddress,
+      chromeDriverLogPath: this.chromeDriverLogPath,
+      webdriverLogPath: this.webdriverLogPath,
+      webdriverOptions: this.webdriverOptions,
+      requireName: this.requireName
+    }
+  }
+
+  exists () {
+    return new Promise((resolve, reject) => {
+      // Binary path is ignored by ChromeDriver if debuggerAddress is set
+      if (this.debuggerAddress) return resolve()
+
+      if (typeof this.path !== 'string') {
+        return reject(Error('Application path must be a string'))
+      }
+
+      fs.stat(this.path, (error, stat) => {
+        if (error) return reject(error)
+        if (stat.isFile()) return resolve()
+        reject(Error('Application path specified is not a file: ' + this.path))
+      })
+    })
+  }
+
+  startChromeDriver () {
+    this.chromeDriver = new ChromeDriver(this.host, this.port, this.nodePath, this.startTimeout, this.workingDirectory, this.chromeDriverLogPath)
+    return this.chromeDriver.start()
+  }
+
+  createClient () {
+    return new Promise((resolve, reject) => {
+      const args = []
+      args.push('spectron-path=' + this.path)
+      this.args.forEach((arg, index) => {
+        args.push('spectron-arg' + index + '=' + arg)
+      })
+
+      for (const name in this.env) {
+        args.push('spectron-env-' + name + '=' + this.env[name])
+      }
+
+      this.chromeDriverArgs.forEach((arg) => {
+        args.push(arg)
+      })
+
+      const isWin = process.platform === 'win32'
+      const launcherPath = path.join(__dirname, isWin ? 'launcher.bat' : 'launcher.js')
+
+      if (process.env.APPVEYOR) {
+        args.push('no-sandbox')
+      }
+
+      const options = {
+        host: this.host,
+        port: this.port,
+        waitforTimeout: this.waitTimeout,
+        connectionRetryCount: this.connectionRetryCount,
+        connectionRetryTimeout: this.connectionRetryTimeout,
+        desiredCapabilities: {
+          browserName: 'electron',
+          chromeOptions: {
+            binary: launcherPath,
+            args: args,
+            debuggerAddress: this.debuggerAddress,
+            windowTypes: ['app', 'webview']
+          }
+        },
+        logOutput: DevNull()
+      }
+
+      if (this.webdriverLogPath) {
+        options.logOutput = this.webdriverLogPath
+        options.logLevel = 'verbose'
+      }
+
+      Object.assign(options, this.webdriverOptions)
+
+      this.client = WebDriver.remote(options)
+      this.addCommands()
+      this.initializeClient(resolve, reject)
+    })
+  }
+
+  initializeClient (resolve, reject) {
+    const maxTries = 10
+    let tries = 0
+    const init = () => {
+      tries++
+      this.client.init().then(resolve, (error) => {
+        if (tries >= maxTries) {
+          error.message = 'Client initialization failed after ' + tries + ' attempts: '
+          error.message += error.type + ' ' + error.message
+          reject(error)
+        } else {
+          global.setTimeout(init, 250)
+        }
+      })
+    }
+    init()
+  }
+
+  addCommands () {
+    this.client.addCommand('waitUntilTextExists', (selector, text, timeout) => {
+      return this.client.waitUntil(() => {
+        return this.client.isExisting(selector).then((exists) => {
+          if (!exists) return false
+          return this.client.getText(selector).then((selectorText) => {
+            return Array.isArray(selectorText) ? selectorText.some(s => s.includes(text)) : selectorText.includes(text)
+          })
         })
+      }, timeout).then(() => { }, (error) => {
+        error.message = 'waitUntilTextExists ' + error.message
+        throw error
       })
-    }, timeout).then(function () { }, function (error) {
-      error.message = 'waitUntilTextExists ' + error.message
-      throw error
     })
-  })
 
-  /**
-   * Utility from webdriverio v5
-   * https://github.com/webdriverio/webdriverio/blob/v5.9.4/packages/webdriverio/src/commands/browser/switchWindow.js
-   */
-  this.client.addCommand('switchWindow', async function (urlOrTitleToMatch) {
-    if (typeof urlOrTitleToMatch !== 'string' && !(urlOrTitleToMatch instanceof RegExp)) {
-      throw new TypeError('Invalid parameter urlOrTitleToMatch: expected a string or a RegExp')
-    }
-
-    const tabs = await this.windowHandles().then(getResponseValue)
-
-    for (const tab of tabs) {
-      await this.window(tab)
-
-      /**
-       * check if url matches
-       */
-      const url = await this.getUrl()
-      if (url.match(urlOrTitleToMatch)) {
-        return tab
+    /**
+     * Utility from webdriverio v5
+     * https://github.com/webdriverio/webdriverio/blob/v5.9.4/packages/webdriverio/src/commands/browser/switchWindow.js
+     */
+    this.client.addCommand('switchWindow', async (urlOrTitleToMatch) => {
+      if (typeof urlOrTitleToMatch !== 'string' && !(urlOrTitleToMatch instanceof RegExp)) {
+        throw new TypeError('Invalid parameter urlOrTitleToMatch: expected a string or a RegExp')
       }
 
-      /**
-       * check title
-       */
-      const title = await this.getTitle()
-      if (title.match(urlOrTitleToMatch)) {
-        return tab
+      const tabs = await this.client.windowHandles().then(getResponseValue)
+
+      for (const tab of tabs) {
+        await this.client.window(tab)
+
+        /**
+         * check if url matches
+         */
+        const url = await this.client.getUrl()
+        if (url.match(urlOrTitleToMatch)) {
+          return tab
+        }
+
+        /**
+         * check title
+         */
+        const title = await this.client.getTitle()
+        if (title.match(urlOrTitleToMatch)) {
+          return tab
+        }
       }
-    }
 
-    throw new Error(`No window found with title or url matching "${urlOrTitleToMatch}"`)
-  })
+      throw new Error(`No window found with title or url matching "${urlOrTitleToMatch}"`)
+    })
 
-  this.client.addCommand('waitUntilWindowLoaded', function (timeout) {
-    return this.waitUntil(function () {
-      return this.webContents.isLoading().then(function (loading) {
-        return !loading
+    this.client.addCommand('waitUntilWindowLoaded', (timeout) => {
+      return this.client.waitUntil(() => {
+        return this.webContents.isLoading().then((loading) => {
+          return !loading
+        })
+      }, timeout).then(() => { }, (error) => {
+        error.message = 'waitUntilWindowLoaded ' + error.message
+        throw error
       })
-    }, timeout).then(function () { }, function (error) {
-      error.message = 'waitUntilWindowLoaded ' + error.message
-      throw error
     })
-  })
 
-  this.client.addCommand('getWindowCount', function () {
-    return this.windowHandles().then(getResponseValue).then(function (handles) {
-      return handles.length
+    this.client.addCommand('getWindowCount', () => {
+      return this.client.windowHandles().then(getResponseValue).then((handles) => {
+        return handles.length
+      })
     })
-  })
 
-  this.client.addCommand('windowByIndex', function (index) {
-    return this.windowHandles().then(getResponseValue).then(function (handles) {
-      return this.window(handles[index])
+    this.client.addCommand('windowByIndex', (index) => {
+      return this.client.windowHandles().then(getResponseValue).then((handles) => {
+        return this.client.window(handles[index])
+      })
     })
-  })
 
-  this.client.addCommand('getSelectedText', function () {
-    return this.execute(function () {
-      return window.getSelection().toString()
-    }).then(getResponseValue)
-  })
+    this.client.addCommand('getSelectedText', () => {
+      return this.client.execute(() => {
+        return window.getSelection().toString()
+      }).then(getResponseValue)
+    })
 
-  this.client.addCommand('getRenderProcessLogs', function () {
-    return this.log('browser').then(getResponseValue)
-  })
+    this.client.addCommand('getRenderProcessLogs', () => {
+      return this.client.log('browser').then(getResponseValue)
+    })
 
-  var self = this
-  this.client.addCommand('getMainProcessLogs', function () {
-    var logs = self.chromeDriver.getLogs()
-    self.chromeDriver.clearLogs()
-    return logs
-  })
+    this.client.addCommand('getMainProcessLogs', () => {
+      const logs = this.chromeDriver.getLogs()
+      this.chromeDriver.clearLogs()
+      return logs
+    })
 
-  Accessibility.addCommand(this.client, this.requireName)
+    Accessibility.addCommand(this.client, this.requireName)
+  }
 }
 
-var getResponseValue = function (response) {
+const getResponseValue = (response) => {
   return response.value
 }
 

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -1,135 +1,134 @@
-var ChildProcess = require('child_process')
-var path = require('path')
-var request = require('request')
-var split = require('split')
+const ChildProcess = require('child_process')
+const path = require('path')
+const request = require('request')
+const split = require('split')
 
-function ChromeDriver (host, port, nodePath, startTimeout, workingDirectory, chromeDriverLogPath) {
-  this.host = host
-  this.port = port
-  this.nodePath = nodePath
-  this.startTimeout = startTimeout
-  this.workingDirectory = workingDirectory
-  this.chromeDriverLogPath = chromeDriverLogPath
+class ChromeDriver {
+  constructor (host, port, nodePath, startTimeout, workingDirectory, chromeDriverLogPath) {
+    this.host = host
+    this.port = port
+    this.nodePath = nodePath
+    this.startTimeout = startTimeout
+    this.workingDirectory = workingDirectory
+    this.chromeDriverLogPath = chromeDriverLogPath
 
-  this.path = require.resolve('electron-chromedriver/chromedriver')
-  this.urlBase = '/wd/hub'
-  this.statusUrl = 'http://' + this.host + ':' + this.port + this.urlBase + '/status'
-  this.logLines = []
-}
-
-ChromeDriver.prototype.start = function () {
-  if (this.process) throw new Error('ChromeDriver already started')
-
-  var args = [
-    this.path,
-    '--port=' + this.port,
-    '--url-base=' + this.urlBase
-  ]
-
-  if (this.chromeDriverLogPath) {
-    args.push('--verbose')
-    args.push('--log-path=' + this.chromeDriverLogPath)
+    this.path = require.resolve('electron-chromedriver/chromedriver')
+    this.urlBase = '/wd/hub'
+    this.statusUrl = 'http://' + this.host + ':' + this.port + this.urlBase + '/status'
+    this.logLines = []
   }
-  var options = {
-    cwd: this.workingDirectory,
-    env: this.getEnvironment()
-  }
-  this.process = ChildProcess.spawn(this.nodePath, args, options)
 
-  var self = this
-  this.exitHandler = function () { self.stop() }
-  global.process.on('exit', this.exitHandler)
+  start () {
+    if (this.process) throw new Error('ChromeDriver already started')
 
-  this.setupLogs()
-  return this.waitUntilRunning()
-}
+    const args = [
+      this.path,
+      '--port=' + this.port,
+      '--url-base=' + this.urlBase
+    ]
 
-ChromeDriver.prototype.waitUntilRunning = function () {
-  var self = this
-  return new Promise(function (resolve, reject) {
-    var startTime = Date.now()
-    var checkIfRunning = function () {
-      self.isRunning(function (running) {
-        if (!self.process) {
-          return reject(Error('ChromeDriver has been stopped'))
-        }
-
-        if (running) {
-          return resolve()
-        }
-
-        var elapsedTime = Date.now() - startTime
-        if (elapsedTime > self.startTimeout) {
-          return reject(Error('ChromeDriver did not start within ' + self.startTimeout + 'ms'))
-        }
-
-        global.setTimeout(checkIfRunning, 100)
-      })
+    if (this.chromeDriverLogPath) {
+      args.push('--verbose')
+      args.push('--log-path=' + this.chromeDriverLogPath)
     }
-    checkIfRunning()
-  })
-}
-
-ChromeDriver.prototype.setupLogs = function () {
-  var linesToIgnore = 2 // First two lines are ChromeDriver specific
-  var lineCount = 0
-
-  this.logLines = []
-
-  var self = this
-  this.process.stdout.pipe(split()).on('data', function (line) {
-    if (lineCount < linesToIgnore) {
-      lineCount++
-      return
+    const options = {
+      cwd: this.workingDirectory,
+      env: this.getEnvironment()
     }
-    self.logLines.push(line)
-  })
-}
+    this.process = ChildProcess.spawn(this.nodePath, args, options)
 
-ChromeDriver.prototype.getEnvironment = function () {
-  var env = {}
-  Object.keys(process.env).forEach(function (key) {
-    env[key] = process.env[key]
-  })
+    this.exitHandler = () => { this.stop() }
+    global.process.on('exit', this.exitHandler)
 
-  if (process.platform === 'win32') {
-    env.SPECTRON_NODE_PATH = process.execPath
-    env.SPECTRON_LAUNCHER_PATH = path.join(__dirname, 'launcher.js')
+    this.setupLogs()
+    return this.waitUntilRunning()
   }
 
-  return env
-}
+  waitUntilRunning () {
+    return new Promise((resolve, reject) => {
+      const startTime = Date.now()
+      const checkIfRunning = () => {
+        this.isRunning((running) => {
+          if (!this.process) {
+            return reject(Error('ChromeDriver has been stopped'))
+          }
 
-ChromeDriver.prototype.stop = function () {
-  if (this.exitHandler) global.process.removeListener('exit', this.exitHandler)
-  this.exitHandler = null
+          if (running) {
+            return resolve()
+          }
 
-  if (this.process) this.process.kill()
-  this.process = null
+          const elapsedTime = Date.now() - startTime
+          if (elapsedTime > this.startTimeout) {
+            return reject(Error('ChromeDriver did not start within ' + this.startTimeout + 'ms'))
+          }
 
-  this.clearLogs()
-}
-
-ChromeDriver.prototype.isRunning = function (callback) {
-  const cb = false
-  var requestOptions = {
-    uri: this.statusUrl,
-    json: true,
-    followAllRedirects: true
+          global.setTimeout(checkIfRunning, 100)
+        })
+      }
+      checkIfRunning()
+    })
   }
-  request(requestOptions, function (error, response, body) {
-    if (error) return callback(cb)
-    if (response.statusCode !== 200) return callback(cb)
-    callback(body && body.value.ready)
-  })
-}
 
-ChromeDriver.prototype.getLogs = function () {
-  return this.logLines.slice()
-}
+  setupLogs () {
+    const linesToIgnore = 2 // First two lines are ChromeDriver specific
+    let lineCount = 0
 
-ChromeDriver.prototype.clearLogs = function () {
-  this.logLines = []
+    this.logLines = []
+
+    this.process.stdout.pipe(split()).on('data', (line) => {
+      if (lineCount < linesToIgnore) {
+        lineCount++
+        return
+      }
+      this.logLines.push(line)
+    })
+  }
+
+  getEnvironment () {
+    const env = {}
+    Object.keys(process.env).forEach((key) => {
+      env[key] = process.env[key]
+    })
+
+    if (process.platform === 'win32') {
+      env.SPECTRON_NODE_PATH = process.execPath
+      env.SPECTRON_LAUNCHER_PATH = path.join(__dirname, 'launcher.js')
+    }
+
+    return env
+  }
+
+  stop () {
+    if (this.exitHandler) global.process.removeListener('exit', this.exitHandler)
+    this.exitHandler = null
+
+    if (this.process) this.process.kill()
+    this.process = null
+
+    this.clearLogs()
+  }
+
+  isRunning (callback) {
+    const cb = false
+    const requestOptions = {
+      uri: this.statusUrl,
+      json: true,
+      followAllRedirects: true
+    }
+    request(requestOptions, (error, response, body) => {
+      if (error) return callback(cb)
+      if (response.statusCode !== 200) return callback(cb)
+      callback(body && body.value.ready)
+    })
+  }
+
+  getLogs () {
+    return this.logLines.slice()
+  }
+
+  clearLogs () {
+    this.logLines = []
+  }
 }
 
 module.exports = ChromeDriver

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -1,20 +1,20 @@
 #!/usr/bin/env node
 
-var ChildProcess = require('child_process')
+const ChildProcess = require('child_process')
 
-var executablePath = null
-var appArgs = []
-var chromeArgs = []
+let executablePath = null
+const appArgs = []
+const chromeArgs = []
 
-process.argv.slice(2).forEach(function (arg) {
-  var indexOfEqualSign = arg.indexOf('=')
+process.argv.slice(2).forEach((arg) => {
+  const indexOfEqualSign = arg.indexOf('=')
   if (indexOfEqualSign === -1) {
     chromeArgs.push(arg)
     return
   }
 
-  var name = arg.substring(0, indexOfEqualSign)
-  var value = arg.substring(indexOfEqualSign + 1)
+  const name = arg.substring(0, indexOfEqualSign)
+  const value = arg.substring(indexOfEqualSign + 1)
   if (name === '--spectron-path') {
     executablePath = value
   } else if (name.indexOf('--spectron-arg') === 0) {
@@ -26,9 +26,9 @@ process.argv.slice(2).forEach(function (arg) {
   }
 })
 
-var args = appArgs.concat(chromeArgs)
-var appProcess = ChildProcess.spawn(executablePath, args)
-appProcess.on('exit', function (code) { process.exit(code) })
+const args = appArgs.concat(chromeArgs)
+const appProcess = ChildProcess.spawn(executablePath, args)
+appProcess.on('exit', (code) => { process.exit(code) })
 appProcess.stderr.pipe(process.stdout)
 appProcess.stdout.pipe(process.stdout)
 appProcess.stdin.pipe(process.stdin)

--- a/test/accessibility-test.js
+++ b/test/accessibility-test.js
@@ -1,17 +1,17 @@
-var helpers = require('./global-setup')
-var path = require('path')
-var { expect } = require('chai')
-var assert = require('assert')
+const helpers = require('./global-setup')
+const path = require('path')
+const { expect } = require('chai')
+const assert = require('assert')
 
-var describe = global.describe
-var it = global.it
-var beforeEach = global.beforeEach
-var afterEach = global.afterEach
+const describe = global.describe
+const it = global.it
+const beforeEach = global.beforeEach
+const afterEach = global.afterEach
 
 describe('app.client.auditAccessibility()', function () {
   helpers.setupTimeout(this)
 
-  var app = null
+  let app = null
 
   afterEach(function () {
     return helpers.stopApplication(app)
@@ -21,12 +21,12 @@ describe('app.client.auditAccessibility()', function () {
     beforeEach(function () {
       return helpers.startApplication({
         args: [path.join(__dirname, 'fixtures', 'accessible')]
-      }).then(function (startedApp) { app = startedApp })
+      }).then((startedApp) => { app = startedApp })
     })
 
     it('resolves to an audit object with no results', function () {
       return app.client.waitUntilWindowLoaded()
-        .auditAccessibility().then(function (audit) {
+        .auditAccessibility().then((audit) => {
           assert.strictEqual(audit.failed, false)
           expect(audit.results).to.have.length(0)
           expect(audit.message).to.equal('Accessibilty audit passed')
@@ -38,12 +38,12 @@ describe('app.client.auditAccessibility()', function () {
     beforeEach(function () {
       return helpers.startApplication({
         args: [path.join(__dirname, 'fixtures', 'not-accessible')]
-      }).then(function (startedApp) { app = startedApp })
+      }).then((startedApp) => { app = startedApp })
     })
 
     it('resolves to an audit object with the results', function () {
       return app.client.waitUntilWindowLoaded()
-        .auditAccessibility().then(function (audit) {
+        .auditAccessibility().then((audit) => {
           assert.strictEqual(audit.failed, true)
           expect(audit.results).to.have.length(3)
 
@@ -60,7 +60,7 @@ describe('app.client.auditAccessibility()', function () {
           expect(audit.results[2].severity).to.equal('Warning')
         })
         .windowByIndex(1)
-        .auditAccessibility().then(function (audit) {
+        .auditAccessibility().then((audit) => {
           assert.strictEqual(audit.failed, true)
           expect(audit.results).to.have.length(1)
 
@@ -72,7 +72,7 @@ describe('app.client.auditAccessibility()', function () {
 
     it('ignores warnings when ignoreWarnings is specified', function () {
       return app.client.waitUntilWindowLoaded()
-        .auditAccessibility({ ignoreWarnings: true }).then(function (audit) {
+        .auditAccessibility({ ignoreWarnings: true }).then((audit) => {
           assert.strictEqual(audit.failed, true)
           expect(audit.results).to.have.length(1)
 
@@ -84,7 +84,7 @@ describe('app.client.auditAccessibility()', function () {
 
     it('ignores rules when ignoreRules is specified', function () {
       return app.client.waitUntilWindowLoaded()
-        .auditAccessibility({ ignoreRules: ['AX_TEXT_01', 'AX_HTML_01'] }).then(function (audit) {
+        .auditAccessibility({ ignoreRules: ['AX_TEXT_01', 'AX_HTML_01'] }).then((audit) => {
           assert.strictEqual(audit.failed, true)
           expect(audit.results).to.have.length(1)
 

--- a/test/application-test.js
+++ b/test/application-test.js
@@ -1,21 +1,21 @@
-var Application = require('..').Application
-var assert = require('assert')
-var fs = require('fs')
-var helpers = require('./global-setup')
-var path = require('path')
-var temp = require('temp').track()
+const Application = require('..').Application
+const assert = require('assert')
+const fs = require('fs')
+const helpers = require('./global-setup')
+const path = require('path')
+const temp = require('temp').track()
 
-var describe = global.describe
-var it = global.it
-var beforeEach = global.beforeEach
-var afterEach = global.afterEach
-var expect = require('chai').expect
+const describe = global.describe
+const it = global.it
+const beforeEach = global.beforeEach
+const afterEach = global.afterEach
+const expect = require('chai').expect
 
 describe('application loading', function () {
   helpers.setupTimeout(this)
 
-  var app = null
-  var tempPath = null
+  let app = null
+  let tempPath = null
 
   beforeEach(function () {
     tempPath = temp.mkdirSync('spectron-temp-dir-')
@@ -32,7 +32,7 @@ describe('application loading', function () {
         HELLO: 'WORLD',
         SPECTRON_TEMP_DIR: tempPath
       }
-    }).then(function (startedApp) { app = startedApp })
+    }).then((startedApp) => { app = startedApp })
   })
 
   afterEach(function () {
@@ -40,7 +40,7 @@ describe('application loading', function () {
   })
 
   it('launches the application', function () {
-    return app.client.windowHandles().then(function (response) {
+    return app.client.windowHandles().then((response) => {
       assert.strictEqual(response.value.length, 1)
     }).browserWindow.getBounds().should.eventually.roughly(5).deep.equal({
       x: 25,
@@ -58,7 +58,7 @@ describe('application loading', function () {
   })
 
   it('passes through env to the launched app', function () {
-    return app.rendererProcess.env().then(function (env) {
+    return app.rendererProcess.env().then((env) => {
       if (process.platform === 'win32') {
         assert.strictEqual(env.foo, 'BAR')
         assert.strictEqual(env.hello, 'WORLD')
@@ -91,9 +91,9 @@ describe('application loading', function () {
 
   describe('stop()', function () {
     it('quits the application', function () {
-      var quitPath = path.join(tempPath, 'quit.txt')
+      const quitPath = path.join(tempPath, 'quit.txt')
       assert.strictEqual(fs.existsSync(quitPath), false)
-      return app.stop().then(function (stoppedApp) {
+      return app.stop().then((stoppedApp) => {
         assert.strictEqual(stoppedApp, app)
         assert.strictEqual(fs.existsSync(quitPath), true)
         assert.strictEqual(app.isRunning(), false)
@@ -101,7 +101,7 @@ describe('application loading', function () {
     })
 
     it('rejects with an error if the application is not running', function () {
-      return app.stop().should.be.fulfilled.then(function () {
+      return app.stop().should.be.fulfilled.then(() => {
         return app.stop().should.be.rejectedWith(Error)
       })
     })
@@ -109,9 +109,9 @@ describe('application loading', function () {
 
   describe('restart()', function () {
     it('restarts the application', function () {
-      var quitPath = path.join(tempPath, 'quit.txt')
+      const quitPath = path.join(tempPath, 'quit.txt')
       assert.strictEqual(fs.existsSync(quitPath), false)
-      return app.restart().then(function (restartedApp) {
+      return app.restart().then((restartedApp) => {
         assert.strictEqual(restartedApp, app)
         assert.strictEqual(fs.existsSync(quitPath), true)
         assert.strictEqual(app.isRunning(), true)
@@ -119,7 +119,7 @@ describe('application loading', function () {
     })
 
     it('rejects with an error if the application is not running', function () {
-      return app.stop().should.be.fulfilled.then(function () {
+      return app.stop().should.be.fulfilled.then(() => {
         return app.restart().should.be.rejectedWith(Error)
       })
     })
@@ -136,7 +136,7 @@ describe('application loading', function () {
   describe('getRenderProcessLogs', function () {
     it('gets the render process console logs and clears them', function () {
       return app.client.waitUntilWindowLoaded()
-        .getRenderProcessLogs().then(function (logs) {
+        .getRenderProcessLogs().then((logs) => {
           expect(logs.length).to.equal(3)
 
           expect(logs[0].message).to.contain('6:14 "render log"')
@@ -151,7 +151,7 @@ describe('application loading', function () {
           expect(logs[2].source).to.equal('console-api')
           expect(logs[2].level).to.equal('SEVERE')
         })
-        .getRenderProcessLogs().then(function (logs) {
+        .getRenderProcessLogs().then((logs) => {
           expect(logs.length).to.equal(0)
         })
     })
@@ -160,27 +160,27 @@ describe('application loading', function () {
   describe('getMainProcessLogs', function () {
     it('gets the main process console logs and clears them', function () {
       return app.client.waitUntilWindowLoaded()
-        .getMainProcessLogs().then(function (logs) {
+        .getMainProcessLogs().then((logs) => {
           expect(logs).to.contain('main log')
           expect(logs).to.contain('main warn')
           expect(logs).to.contain('main error')
         })
-        .getMainProcessLogs().then(function (logs) {
+        .getMainProcessLogs().then((logs) => {
           expect(logs.length).to.equal(0)
         })
     })
 
     it('does not include any deprecation warnings', function () {
       return app.client.waitUntilWindowLoaded()
-        .getMainProcessLogs().then(function (logs) {
-          logs.forEach(function (log) {
+        .getMainProcessLogs().then((logs) => {
+          logs.forEach((log) => {
             expect(log).not.to.contain('(electron)')
           })
         })
     })
 
     it('clears the logs when the application is stopped', function () {
-      return app.stop().then(function () {
+      return app.stop().then(() => {
         expect(app.chromeDriver.getLogs().length).to.equal(0)
       })
     })
@@ -199,14 +199,14 @@ describe('application loading', function () {
         y: 0,
         width: 10,
         height: 10
-      }).then(function (buffer) {
+      }).then((buffer) => {
         expect(buffer).to.be.an.instanceof(Buffer)
         expect(buffer.length).to.be.above(0)
       })
     })
 
     it('returns a Buffer screenshot of the entire page when no rectangle is specified', function () {
-      return app.browserWindow.capturePage().then(function (buffer) {
+      return app.browserWindow.capturePage().then((buffer) => {
         expect(buffer).to.be.an.instanceof(Buffer)
         expect(buffer.length).to.be.above(0)
       })
@@ -215,9 +215,9 @@ describe('application loading', function () {
 
   describe('webContents.savePage', function () {
     it('saves the page to the specified path', function () {
-      var filePath = path.join(tempPath, 'page.html')
-      return app.webContents.savePage(filePath, 'HTMLComplete').then(function () {
-        var html = fs.readFileSync(filePath, 'utf8')
+      const filePath = path.join(tempPath, 'page.html')
+      return app.webContents.savePage(filePath, 'HTMLComplete').then(() => {
+        const html = fs.readFileSync(filePath, 'utf8')
         expect(html).to.contain('<title>Test</title>')
         expect(html).to.contain('Hello')
       })
@@ -230,19 +230,19 @@ describe('application loading', function () {
 
   describe('webContents.executeJavaScript', function () {
     it('executes the given script and returns the result of its last statement (sync)', function () {
-      return app.webContents.executeJavaScript('1 + 2').then(function (result) {
+      return app.webContents.executeJavaScript('1 + 2').then((result) => {
         expect(result).to.equal(3)
       })
     })
 
     it('executes the given script and returns the result of its last statement (async)', function () {
       return app.webContents.executeJavaScript(`
-        new Promise(function(resolve){
-          setTimeout(function(){
+        new Promise((resolve) => {
+          setTimeout(() => {
             resolve("ok")
           }, 1000)
         })`
-      ).then(function (result) {
+      ).then((result) => {
         expect(result).to.equal('ok')
       })
     })

--- a/test/commands-test.js
+++ b/test/commands-test.js
@@ -1,22 +1,22 @@
-var fs = require('fs')
-var helpers = require('./global-setup')
-var path = require('path')
-var temp = require('temp').track()
+const fs = require('fs')
+const helpers = require('./global-setup')
+const path = require('path')
+const temp = require('temp').track()
 
-var describe = global.describe
-var it = global.it
-var before = global.before
-var after = global.after
+const describe = global.describe
+const it = global.it
+const before = global.before
+const after = global.after
 
 describe('window commands', function () {
   helpers.setupTimeout(this)
 
-  var app = null
+  let app = null
 
   before(function () {
     return helpers.startApplication({
       args: [path.join(__dirname, 'fixtures', 'app')]
-    }).then(function (startedApp) { app = startedApp })
+    }).then((startedApp) => { app = startedApp })
   })
 
   after(function () {
@@ -122,24 +122,24 @@ describe('window commands', function () {
   describe('browserWindow.isMaximized()', function () {
     it('returns true when the window is maximized, false otherwise', function () {
       return app.browserWindow.isMaximized().should.eventually.be.false
-        .browserWindow.maximize().waitUntil(function () {
+        .browserWindow.maximize().waitUntil(() => {
           // FIXME window maximized state is never true on CI
           if (process.env.CI) return Promise.resolve(true)
 
-          return this.browserWindow.isMaximized()
-        }, 5000).then(function () { })
+          return app.browserWindow.isMaximized()
+        }, 5000).then(() => { })
     })
   })
 
   describe('browserWindow.isMinimized()', function () {
     it('returns true when the window is minimized, false otherwise', function () {
       return app.browserWindow.isMinimized().should.eventually.be.false
-        .browserWindow.minimize().waitUntil(function () {
+        .browserWindow.minimize().waitUntil(() => {
           // FIXME window minimized state is never true on CI
           if (process.env.CI) return Promise.resolve(true)
 
-          return this.browserWindow.isMinimized()
-        }, 5000).then(function () { })
+          return app.browserWindow.isMinimized()
+        }, 5000).then(() => { })
     })
   })
 
@@ -186,7 +186,7 @@ describe('window commands', function () {
 
   describe('electron.remote.app.getPath()', function () {
     it('returns the path for the given name', function () {
-      var tempDir = fs.realpathSync(temp.dir)
+      const tempDir = fs.realpathSync(temp.dir)
       return app.electron.remote.app.setPath('music', tempDir)
         .electron.remote.app.getPath('music').should.eventually.equal(tempDir)
     })

--- a/test/example-test.js
+++ b/test/example-test.js
@@ -1,21 +1,21 @@
 // Test for examples included in README.md
-var helpers = require('./global-setup')
-var path = require('path')
+const helpers = require('./global-setup')
+const path = require('path')
 
-var describe = global.describe
-var it = global.it
-var beforeEach = global.beforeEach
-var afterEach = global.afterEach
+const describe = global.describe
+const it = global.it
+const beforeEach = global.beforeEach
+const afterEach = global.afterEach
 
 describe('example application launch', function () {
   helpers.setupTimeout(this)
 
-  var app = null
+  let app = null
 
   beforeEach(function () {
     return helpers.startApplication({
       args: [path.join(__dirname, 'fixtures', 'example')]
-    }).then(function (startedApp) { app = startedApp })
+    }).then((startedApp) => { app = startedApp })
   })
 
   afterEach(function () {

--- a/test/fixtures/accessible/main.js
+++ b/test/fixtures/accessible/main.js
@@ -1,8 +1,8 @@
-var { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow } = require('electron')
 
-var mainWindow = null
+let mainWindow = null
 
-app.on('ready', function () {
+app.on('ready', () => {
   mainWindow = new BrowserWindow({
     center: true,
     width: 800,

--- a/test/fixtures/app/main.js
+++ b/test/fixtures/app/main.js
@@ -1,11 +1,11 @@
-var { app, BrowserWindow, ipcMain } = require('electron')
-var fs = require('fs')
-var path = require('path')
+const { app, BrowserWindow, ipcMain } = require('electron')
+const fs = require('fs')
+const path = require('path')
 
-var mainWindow = null
+let mainWindow = null
 app.allowRendererProcessReuse = true
 
-app.on('ready', function () {
+app.on('ready', () => {
   console.log('main log')
   console.warn('main warn')
   console.error('main error')
@@ -23,15 +23,15 @@ app.on('ready', function () {
     }
   })
   mainWindow.loadFile('index.html')
-  mainWindow.on('closed', function () { mainWindow = null })
+  mainWindow.on('closed', () => { mainWindow = null })
 })
 
-app.on('will-quit', function () {
+app.on('will-quit', () => {
   if (fs.existsSync(process.env.SPECTRON_TEMP_DIR)) {
     fs.writeFileSync(path.join(process.env.SPECTRON_TEMP_DIR, 'quit.txt'), '')
   }
 })
 
-ipcMain.on('ipc-event', function (event, count) {
+ipcMain.on('ipc-event', (event, count) => {
   global.ipcEventCount += count
 })

--- a/test/fixtures/example/index.html
+++ b/test/fixtures/example/index.html
@@ -52,17 +52,17 @@
     </style>
     <script>
       document.addEventListener('DOMContentLoaded', function () {
-        document.querySelector('.btn-make-bigger').addEventListener('click', function () {
-          var remote = require('electron').remote
-          var currentWindow = remote.getCurrentWindow()
-          var size = currentWindow.getSize()
+        document.querySelector('.btn-make-bigger').addEventListener('click', () => {
+          const remote = require('electron').remote
+          const currentWindow = remote.getCurrentWindow()
+          const size = currentWindow.getSize()
           currentWindow.setSize(size[0] + 10, size[1] + 10)
         })
 
-        document.querySelector('.btn-make-smaller').addEventListener('click', function () {
-          var remote = require('electron').remote
-          var currentWindow = remote.getCurrentWindow()
-          var size = currentWindow.getSize()
+        document.querySelector('.btn-make-smaller').addEventListener('click', () => {
+          const remote = require('electron').remote
+          const currentWindow = remote.getCurrentWindow()
+          const size = currentWindow.getSize()
           currentWindow.setSize(size[0] - 10, size[1] - 10)
         })
       })

--- a/test/fixtures/example/main.js
+++ b/test/fixtures/example/main.js
@@ -1,8 +1,8 @@
-var { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow } = require('electron')
 
-var mainWindow = null
+let mainWindow = null
 
-app.on('ready', function () {
+app.on('ready', () => {
   mainWindow = new BrowserWindow({
     center: true,
     width: 800,
@@ -14,5 +14,5 @@ app.on('ready', function () {
     }
   })
   mainWindow.loadFile('index.html')
-  mainWindow.on('closed', function () { mainWindow = null })
+  mainWindow.on('closed', () => { mainWindow = null })
 })

--- a/test/fixtures/multi-window/main.js
+++ b/test/fixtures/multi-window/main.js
@@ -1,9 +1,9 @@
-var { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow } = require('electron')
 
-var topWindow = null
-var bottomWindow = null
+let topWindow = null
+let bottomWindow = null
 
-app.on('ready', function () {
+app.on('ready', () => {
   topWindow = new BrowserWindow({
     x: 25,
     y: 35,
@@ -14,7 +14,7 @@ app.on('ready', function () {
     }
   })
   topWindow.loadFile('index-top.html')
-  topWindow.on('closed', function () { topWindow = null })
+  topWindow.on('closed', () => { topWindow = null })
 
   bottomWindow = new BrowserWindow({
     x: 25,
@@ -26,5 +26,5 @@ app.on('ready', function () {
     }
   })
   bottomWindow.loadFile('index-bottom.html')
-  bottomWindow.on('closed', function () { bottomWindow = null })
+  bottomWindow.on('closed', () => { bottomWindow = null })
 })

--- a/test/fixtures/no-node-integration/main.js
+++ b/test/fixtures/no-node-integration/main.js
@@ -1,8 +1,8 @@
-var { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow } = require('electron')
 
-var mainWindow = null
+let mainWindow = null
 
-app.on('ready', function () {
+app.on('ready', () => {
   mainWindow = new BrowserWindow({
     x: 25,
     y: 35,
@@ -13,5 +13,5 @@ app.on('ready', function () {
     }
   })
   mainWindow.loadFile('index.html')
-  mainWindow.on('closed', function () { mainWindow = null })
+  mainWindow.on('closed', () => { mainWindow = null })
 })

--- a/test/fixtures/not-accessible/main.js
+++ b/test/fixtures/not-accessible/main.js
@@ -1,8 +1,8 @@
-var { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow } = require('electron')
 
-var mainWindow = null
+let mainWindow = null
 
-app.on('ready', function () {
+app.on('ready', () => {
   mainWindow = new BrowserWindow({
     center: true,
     width: 800,
@@ -13,5 +13,5 @@ app.on('ready', function () {
     }
   })
   mainWindow.loadFile('index.html')
-  mainWindow.on('closed', function () { mainWindow = null })
+  mainWindow.on('closed', () => { mainWindow = null })
 })

--- a/test/fixtures/require-name/main.js
+++ b/test/fixtures/require-name/main.js
@@ -1,9 +1,9 @@
-var { app, BrowserWindow } = require('electron')
-var path = require('path')
+const { app, BrowserWindow } = require('electron')
+const path = require('path')
 
-var mainWindow = null
+let mainWindow = null
 
-app.on('ready', function () {
+app.on('ready', () => {
   mainWindow = new BrowserWindow({
     x: 25,
     y: 35,
@@ -15,5 +15,5 @@ app.on('ready', function () {
     }
   })
   mainWindow.loadFile('index.html')
-  mainWindow.on('closed', function () { mainWindow = null })
+  mainWindow.on('closed', () => { mainWindow = null })
 })

--- a/test/fixtures/slow/main.js
+++ b/test/fixtures/slow/main.js
@@ -1,8 +1,8 @@
-var { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow } = require('electron')
 
-var mainWindow = null
+let mainWindow = null
 
-app.on('ready', function () {
+app.on('ready', () => {
   mainWindow = new BrowserWindow({
     x: 25,
     y: 35,
@@ -13,5 +13,5 @@ app.on('ready', function () {
     }
   })
   mainWindow.loadFile('index.html')
-  mainWindow.on('closed', function () { mainWindow = null })
+  mainWindow.on('closed', () => { mainWindow = null })
 })

--- a/test/fixtures/web-view/main.js
+++ b/test/fixtures/web-view/main.js
@@ -1,8 +1,8 @@
-var { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow } = require('electron')
 
-var mainWindow = null
+let mainWindow = null
 
-app.on('ready', function () {
+app.on('ready', () => {
   mainWindow = new BrowserWindow({
     center: true,
     width: 800,
@@ -15,5 +15,5 @@ app.on('ready', function () {
     }
   })
   mainWindow.loadFile('index.html')
-  mainWindow.on('closed', function () { mainWindow = null })
+  mainWindow.on('closed', () => { mainWindow = null })
 })

--- a/test/global-setup.js
+++ b/test/global-setup.js
@@ -1,19 +1,19 @@
-var Application = require('..').Application
-var assert = require('assert')
-var chai = require('chai')
-var chaiAsPromised = require('chai-as-promised')
-var chaiRoughly = require('chai-roughly')
+const Application = require('..').Application
+const assert = require('assert')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const chaiRoughly = require('chai-roughly')
 
-var path = require('path')
+const path = require('path')
 
-global.before(function () {
+global.before(() => {
   chai.should()
   chai.use(chaiAsPromised)
   chai.use(chaiRoughly)
 })
 
-exports.getElectronPath = function () {
-  var electronPath = path.join(__dirname, '..', 'node_modules', '.bin', 'electron')
+exports.getElectronPath = () => {
+  let electronPath = path.join(__dirname, '..', 'node_modules', '.bin', 'electron')
   if (process.platform === 'win32') electronPath += '.cmd'
   return electronPath
 }
@@ -26,22 +26,22 @@ exports.setupTimeout = function (test) {
   }
 }
 
-exports.startApplication = function (options) {
+exports.startApplication = (options) => {
   options.path = exports.getElectronPath()
   if (process.env.CI) options.startTimeout = 30000
 
-  var app = new Application(options)
-  return app.start().then(function () {
+  const app = new Application(options)
+  return app.start().then(() => {
     assert.strictEqual(app.isRunning(), true)
     chaiAsPromised.transferPromiseness = app.transferPromiseness
     return app
   })
 }
 
-exports.stopApplication = function (app) {
+exports.stopApplication = (app) => {
   if (!app || !app.isRunning()) return
 
-  return app.stop().then(function () {
+  return app.stop().then(() => {
     assert.strictEqual(app.isRunning(), false)
   })
 }

--- a/test/multi-window-test.js
+++ b/test/multi-window-test.js
@@ -1,20 +1,20 @@
-var helpers = require('./global-setup')
-var path = require('path')
+const helpers = require('./global-setup')
+const path = require('path')
 
-var describe = global.describe
-var it = global.it
-var beforeEach = global.beforeEach
-var afterEach = global.afterEach
+const describe = global.describe
+const it = global.it
+const beforeEach = global.beforeEach
+const afterEach = global.afterEach
 
 describe('multiple windows', function () {
   helpers.setupTimeout(this)
 
-  var app = null
+  let app = null
 
   beforeEach(function () {
     return helpers.startApplication({
       args: [path.join(__dirname, 'fixtures', 'multi-window')]
-    }).then(function (startedApp) { app = startedApp })
+    }).then((startedApp) => { app = startedApp })
   })
 
   afterEach(function () {

--- a/test/no-node-integration-test.js
+++ b/test/no-node-integration-test.js
@@ -1,21 +1,21 @@
-var helpers = require('./global-setup')
-var path = require('path')
-var assert = require('assert')
+const helpers = require('./global-setup')
+const path = require('path')
+const assert = require('assert')
 
-var describe = global.describe
-var it = global.it
-var before = global.before
-var after = global.after
+const describe = global.describe
+const it = global.it
+const before = global.before
+const after = global.after
 
 describe('when nodeIntegration is set to false', function () {
   helpers.setupTimeout(this)
 
-  var app = null
+  let app = null
 
   before(function () {
     return helpers.startApplication({
       args: [path.join(__dirname, 'fixtures', 'no-node-integration')]
-    }).then(function (startedApp) { app = startedApp })
+    }).then((startedApp) => { app = startedApp })
   })
 
   after(function () {

--- a/test/require-name-test.js
+++ b/test/require-name-test.js
@@ -1,21 +1,21 @@
-var helpers = require('./global-setup')
-var path = require('path')
+const helpers = require('./global-setup')
+const path = require('path')
 
-var describe = global.describe
-var it = global.it
-var beforeEach = global.beforeEach
-var afterEach = global.afterEach
+const describe = global.describe
+const it = global.it
+const beforeEach = global.beforeEach
+const afterEach = global.afterEach
 
 describe('requireName option to Application', function () {
   helpers.setupTimeout(this)
 
-  var app = null
+  let app = null
 
   beforeEach(function () {
     return helpers.startApplication({
       args: [path.join(__dirname, 'fixtures', 'require-name')],
       requireName: 'electronRequire'
-    }).then(function (startedApp) { app = startedApp })
+    }).then((startedApp) => { app = startedApp })
   })
 
   afterEach(function () {

--- a/test/slow-page-test.js
+++ b/test/slow-page-test.js
@@ -1,20 +1,20 @@
-var helpers = require('./global-setup')
-var path = require('path')
+const helpers = require('./global-setup')
+const path = require('path')
 
-var describe = global.describe
-var it = global.it
-var before = global.before
-var after = global.after
+const describe = global.describe
+const it = global.it
+const before = global.before
+const after = global.after
 
 describe('Slow loading page', function () {
   helpers.setupTimeout(this)
 
-  var app = null
+  let app = null
 
   before(function () {
     return helpers.startApplication({
       args: [path.join(__dirname, 'fixtures', 'slow')]
-    }).then(function (startedApp) { app = startedApp })
+    }).then((startedApp) => { app = startedApp })
   })
 
   after(function () {

--- a/test/web-view-test.js
+++ b/test/web-view-test.js
@@ -1,20 +1,20 @@
-var helpers = require('./global-setup')
-var path = require('path')
+const helpers = require('./global-setup')
+const path = require('path')
 
-var describe = global.describe
-var it = global.it
-var beforeEach = global.beforeEach
-var afterEach = global.afterEach
+const describe = global.describe
+const it = global.it
+const beforeEach = global.beforeEach
+const afterEach = global.afterEach
 
 describe('<webview> tags', function () {
   helpers.setupTimeout(this)
 
-  var app = null
+  let app = null
 
   beforeEach(function () {
     return helpers.startApplication({
       args: [path.join(__dirname, 'fixtures', 'web-view')]
-    }).then(function (startedApp) { app = startedApp })
+    }).then((startedApp) => { app = startedApp })
   })
 
   afterEach(function () {
@@ -26,8 +26,8 @@ describe('<webview> tags', function () {
     // TODO: this issue should be fixed by waitUntilWindowLoaded instead of this workaround.
     return app.client.windowHandles()
       .waitUntilWindowLoaded()
-      .waitUntil(function () {
-        return this.getWindowCount().then(function (count) {
+      .waitUntil(() => {
+        return app.client.getWindowCount().then((count) => {
           return count === 2
         })
       })


### PR DESCRIPTION
### Background

I try to update Spectron to WebDriverIO v5 (#349), but I realized I have to refactor it before update.

### Changes

Use ES6 features: class keyword, const/let, arrow functions.

- Use `class` keywords for Application, Api, ChromeDriver
- Use `const` or `let` for definition variables instead of `var`
- Use arrow functions instead of `function()`
    - Except [mocha.is](https://mochajs.org/#arrow-functions) and `addClientProperty`, `addClientProperties` in `api.js` (this script uses `this`)
    - Almost all `self` could be deleted