### PR TITLE
Remove the '--enable-logging' argument when running on Windows

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -27,6 +27,12 @@ process.argv.slice(2).forEach(function (arg) {
 })
 
 var args = appArgs.concat(chromeArgs)
+
+// Disables the --enable-logging flag on Windows, which causes extranneous console host windows to appear
+if (process.platform === 'win32') {
+  args.splice(args.indexOf('--enable-logging'), 1)
+}
+
 var appProcess = ChildProcess.spawn(executablePath, args)
 appProcess.on('exit', function (code) { process.exit(code) })
 appProcess.stderr.pipe(process.stdout)


### PR DESCRIPTION
This forcibly removes the `--enable-logging` flag prior to launch when running Spectron on Windows.

This will fix https://github.com/electron-userland/spectron/issues/60