### PR TITLE
Chrome extension throwing a “Cannot convert undefined or null to object” error

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -139,6 +139,7 @@ Api.prototype.loadApi = function () {
 
     function addMainProcessModules() {
       api.electron.remote = {};
+      if (typeof electron.remote !== 'object') return;
       Object.getOwnPropertyNames(electron.remote).forEach(function (key) {
         if (ignoreModule(key)) return;
         if (isRemoteFunction(key)) {
@@ -161,6 +162,7 @@ Api.prototype.loadApi = function () {
     }
 
     function addBrowserWindow() {
+      if (typeof electron.remote !== 'object') return;
       const currentWindow = electron.remote.getCurrentWindow();
       for (const name in currentWindow) {
         if (ignoreApi(name)) continue;
@@ -172,6 +174,7 @@ Api.prototype.loadApi = function () {
     }
 
     function addWebContents() {
+      if (typeof electron.remote !== 'object') return;
       const webContents = electron.remote.getCurrentWebContents();
       for (const name in webContents) {
         if (ignoreApi(name)) continue;

--- a/lib/application.js
+++ b/lib/application.js
@@ -88,7 +88,26 @@ Application.prototype.stop = function () {
     };
 
     if (self.api.nodeIntegration) {
-      self.client.electron.remote.app.quit().then(endClient, reject);
+      // Check if electron remote app has really a quit() function
+      if (
+        Object.prototype.hasOwnProperty.call(self.client.electron, 'remote') &&
+        Object.prototype.hasOwnProperty.call(
+          self.client.electron.remote,
+          'app'
+        ) &&
+        typeof self.client.electron.remote.app.quit === 'function'
+      ) {
+        self.client.electron.remote.app.quit().then(endClient, reject);
+      } else {
+        const fakeAppQuit = new Promise(function (resolve, reject) {
+          try {
+            resolve();
+          } catch (error) {
+            reject(Error('fakeAppQuit Promise not valid'));
+          }
+        });
+        fakeAppQuit.then(endClient, reject);
+      }
     } else {
       self.client
         .windowByIndex(0)


### PR DESCRIPTION
When I try to start Spectron, i got a `javascript error: javascript error: Cannot convert undefined or null to object` in the console

To debug this i search lot where can be. I finally found the way to reproduce that error.

## Install Debugging tools in VS Code

I install [Debugging tests in VS Code](https://github.com/microsoft/vscode-recipes/tree/master/debugging-mocha-tests) tools to help me with this debugging.

## Start Debugging

I try to add many break points to find the possible error.

The breakpoint they was the more useful : 
- node_modules/webdriver/build/request.js at line 132 with the variables `fullRequestOptions`

![Capture d’écran, le 2020-10-12 à 16 50 05](https://user-images.githubusercontent.com/5769264/95789179-0a7f7c00-0cab-11eb-9cd6-a3c0490af437.png)

I finally found Spectron send Chromedrive debug some functions and the Chromedrive callback. And for this last call back Chromedrive send the `javascript error: Cannot convert undefined or null to object`

![Capture d’écran, le 2020-10-12 à 16 54 34](https://user-images.githubusercontent.com/5769264/95789537-b2954500-0cab-11eb-8f15-d392d698d5f9.png)

When you check into this request, you will find the URL use for this request 👍 

![Capture d’écran, le 2020-10-12 à 16 54 45](https://user-images.githubusercontent.com/5769264/95789541-b5903580-0cab-11eb-8210-8de3971ab1a1.png)

The URL we got is `http://127.0.0.1:9515/session/{{session_name}}/execute/sync`. The `session_name` is a random session UID

So go back to the `fullRequestOptions` and you will see the exact request send to the debug tool

![Capture d’écran, le 2020-10-12 à 16 58 34](https://user-images.githubusercontent.com/5769264/95789842-4404b700-0cac-11eb-82c2-42b83be13bf2.png)

And next we found these 2 parameters were sent 

![Capture d’écran, le 2020-10-12 à 16 59 59](https://user-images.githubusercontent.com/5769264/95789945-72829200-0cac-11eb-828f-5add014905a3.png)

## Try to investigate

I open my Postman application and I try to send POST request with the same parameters.

```curl
curl --location --request POST 'http://127.0.0.1:9515/session/55ac1420d478c0b597644644fc2009bf/execute/sync' \
--header 'Content-Type: application/json' \
--data-raw '{
    "args": [
        "require"
    ],
    "script": "return (function (requireName) {.....}).apply(null, arguments)""
}'
````

Bam!!! We have the error
<img width="995" alt="Capture d’écran, le 2020-10-12 à 17 08 04" src="https://user-images.githubusercontent.com/5769264/95790529-88dd1d80-0cad-11eb-9983-763e771385f8.png">

## Correct the error

I finally found `electron.remote` not initiated at the point of the code. So I simply add the code to protect this and `et voilà`! 
