### PR TITLE
Used W3C flag aware function for setting timeouts.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -57,11 +57,11 @@ Application.prototype.start = function () {
       return self.api.initialize();
     })
     .then(function () {
-      return self.client.setTimeouts(
-        self.waitTimeout,
-        self.waitTimeout,
-        self.waitTimeout
-      );
+      return self.client.setTimeout({
+        implicit: self.waitTimeout,
+        'page load': self.waitTimeout,
+        script: self.waitTimeout
+      });
     })
     .then(function () {
       self.running = true;


### PR DESCRIPTION
In order to properly set timeout in case of `w3c` flag being set to false (when passing options to WebdriverIO) we need to use  a function that is aware of this flag and will choose appropriate branch of code to execute. 