### PR TITLE
Change prepack script to prepare, to fix errors installing directly from Git

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "eslint \"**/*.js\" \"**/*.ts\" && prettier --check \"**/*.js\" \"**/*.ts\"",
     "prettier:write": "prettier --write \"**/*.js\" \"**/*.ts\"",
-    "prepack": "check-for-leaks",
+    "prepare": "check-for-leaks",
     "prepush": "check-for-leaks",
     "pretest": "tsc lib/spectron.d.ts",
     "test": "npm run lint && xvfb-maybe mocha",


### PR DESCRIPTION
The `prepare` script is run with `devDependencies` installed, while the `prepack` script is not.  This fixes “`check-for-leaks: command not found`” when installing spectron directly from Git (`npm install electron-userland/spectron`).

https://docs.npmjs.com/cli/v6/using-npm/scripts