### PR TITLE
Add goog:loggingPrefs to webdriver options

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -206,6 +206,9 @@ Application.prototype.createClient = function () {
           args: args,
           debuggerAddress: self.debuggerAddress,
           windowTypes: ['app', 'webview']
+        },
+        'goog:loggingPrefs': {
+          browser: 'ALL'
         }
       },
       logOutput: DevNull()


### PR DESCRIPTION
A goog:loggingPrefs value of `browser: ALL` makes all console logs
available to getLogs('browser'). Previously, calls to getLogs('browser')
would only return console.warn or console.error logs.