### PR TITLE
Fix doc and type

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,11 +206,11 @@ property which do not require Node integration.
 
 #### client
 
-Spectron uses [WebdriverIO](http://webdriver.io) and exposes the managed
+Spectron uses [WebdriverIO](https://webdriver.io) and exposes the managed
 `client` property on the created `Application` instances.
 
 The `client` API is WebdriverIO's `browser` object. Documentation can be found
-[here](http://webdriver.io/api.html).
+[here](https://webdriver.io/docs/api).
 
 Several additional commands are provided specific to Electron.
 
@@ -219,8 +219,10 @@ All the commands return a `Promise`.
 So if you wanted to get the text of an element you would do:
 
 ```js
-app.client.getText('#error-alert').then(function (errorText) {
-  console.log('The #error-alert text content is ' + errorText)
+app.client.$('#error-alert').then(function (element) {
+  element.getText().then(function (errorText) {
+    console.log('The #error-alert text content is ' + errorText)
+  })
 })
 ```
 
@@ -237,9 +239,8 @@ API in your tests you would do:
 
 ```js
 app.electron.clipboard.writeText('pasta')
-   .electron.clipboard.readText().then(function (clipboardText) {
-     console.log('The clipboard text is ' + clipboardText)
-   })
+const clipboardText = app.electron.clipboard.readText()
+console.log('The clipboard text is ' + clipboardText)
 ```
 
 #### browserWindow
@@ -649,7 +650,7 @@ test.afterEach(t => {
   return t.context.app.stop();
 });
 
-test(t => {
+test('opens a window', t => {
   return t.context.app.client.waitUntilWindowLoaded()
     .getWindowCount().then(count => {
       t.is(count, 1);
@@ -686,7 +687,7 @@ test.afterEach.always(async t => {
   await t.context.app.stop();
 });
 
-test(async t => {
+test('example', async t => {
   const app = t.context.app;
   await app.client.waitUntilWindowLoaded();
 

--- a/lib/spectron.d.ts
+++ b/lib/spectron.d.ts
@@ -118,7 +118,9 @@ declare module 'spectron' {
     ): Promise<AccessibilityAuditResult>;
   }
 
-  export interface SpectronWindow extends Electron.BrowserWindow {
+  type PromisedBrowserWindow = { [P in keyof Electron.BrowserWindow]: Electron.BrowserWindow[P] extends (...args: infer A) => infer R ? (...args: A) => Promise<R> : undefined };
+
+  export interface SpectronWindow extends PromisedBrowserWindow {
     capturePage(): Promise<Electron.NativeImage>;
   }
 
@@ -126,7 +128,7 @@ declare module 'spectron' {
     savePage(
       fullPath: string,
       saveType: 'HTMLOnly' | 'HTMLComplete' | 'MHTML',
-      callback?: (eror: Error) => void
+      callback?: (error: Error) => void
     ): boolean;
     savePage(
       fullPath: string,

--- a/lib/spectron.d.ts
+++ b/lib/spectron.d.ts
@@ -118,11 +118,7 @@ declare module 'spectron' {
     ): Promise<AccessibilityAuditResult>;
   }
 
-  type PromisedBrowserWindow = { [P in keyof Electron.BrowserWindow]: Electron.BrowserWindow[P] extends (...args: infer A) => infer R ? (...args: A) => Promise<R> : undefined };
-
-  export interface SpectronWindow extends PromisedBrowserWindow {
-    capturePage(): Promise<Electron.NativeImage>;
-  }
+  export type SpectronWindow = { [P in keyof Electron.BrowserWindow]: Electron.BrowserWindow[P] extends (...args: infer A) => infer R ? (...args: A) => Promise<R> : undefined };
 
   export interface SpectronWebContents extends Electron.WebContents {
     savePage(

--- a/lib/spectron.d.ts
+++ b/lib/spectron.d.ts
@@ -118,7 +118,13 @@ declare module 'spectron' {
     ): Promise<AccessibilityAuditResult>;
   }
 
-  export type SpectronWindow = { [P in keyof Electron.BrowserWindow]: Electron.BrowserWindow[P] extends (...args: infer A) => infer R ? (...args: A) => Promise<R> : undefined };
+  export type SpectronWindow = {
+    [P in keyof Electron.BrowserWindow]: Electron.BrowserWindow[P] extends (
+      ...args: infer A
+    ) => infer R
+      ? (...args: A) => Promise<R>
+      : undefined;
+  };
 
   export interface SpectronWebContents extends Electron.WebContents {
     savePage(


### PR DESCRIPTION
1. Fix old and broken urls of webdriver.io
2. Fix sample code in README
3. Fix type of SpectronWindow

`2.` helps some issues like #815, #831 .

`3.` fixes SpectronWindow type:

```ts
import { Application } from "spectron";
let app: Application;

// ... skip setup ...

app.client.getText('#error-alert'); // compile error
const windowCount: number = app.client.getWindowCount(); // compile error
const promisedWindowCount: Promise<number> = app.client.getWindowCount();
```