### PR TITLE
Call for Chromedriver to stop when application is not running

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -75,6 +75,7 @@ Application.prototype.stop = function () {
   const self = this;
 
   if (!self.isRunning()) {
+    self.chromeDriver.stop()
     return Promise.reject(Error('Application not running'));
   }
 


### PR DESCRIPTION
The current `Application.stop` call looks like so:
```javascript
  if (!self.isRunning()) {
    return Promise.reject(Error('Application not running'));
  }
```

What this PR is requesting is to add in `chromedriver.stop()` to the above command. We've found many instances where the application crashes, but chromedriver remains open. Likely due to this call only verifying if the application is open or not before returning the promise. This leads to additional Electron instances spawning on subsequent test runs due to Chromedriver staying in the background.

We've been running a local fork of this for the last year and have found this to be a reliable way to ensure that every service that's part of Spectron fully shuts down on a crash.